### PR TITLE
ci: pin actions to commit hashes and add permissions block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,16 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions (`actions/checkout`, `pnpm/action-setup`, `actions/setup-node`) to immutable commit hashes instead of mutable `@v4` tags to prevent supply chain attacks
- Add explicit `permissions: contents: read` to follow the least-privilege principle for the `GITHUB_TOKEN`

Fixes CodeQL alerts #31 (`actions/missing-workflow-permissions`) and #32 (`actions/unpinned-tag`).

Additionally dismissed 24 false positive CodeQL alerts:
- **6x `js/weak-cryptographic-algorithm`** (#17-22): UUID v5 uses SHA-1 by RFC 9562 spec for identifier generation, not for cryptographic security. Source is bundled `langsmith` SDK dependency.
- **12x `js/file-system-race`** (#9-12, #23-30): TOCTOU between `statSync()` size check and read only affects performance strategy (chunked vs full read), not security. Files are user-owned.
- **6x `js/insecure-temporary-file`** (#7-8, #13-16): State files at `~/.claude/state/`, transcripts at `~/.claude/projects/` — not os tmpdir. Lock file uses `O_EXCL`. Test files use randomized tmpdir paths.

## Test plan

- [x] CI workflow runs successfully with pinned hashes
- [x] Verify the pinned hashes match the v4 tags for each action