### PR TITLE
feat: add support for tracing repo name and provider

### DIFF
--- a/bundle/post-compact.js
+++ b/bundle/post-compact.js
@@ -803,7 +803,7 @@ function v7(options, buf, offset) {
 }
 var v7_default = v7;
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/constants.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/constants.js
 var GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 var GEN_AI_SYSTEM = "gen_ai.system";
 var GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -838,7 +838,7 @@ var LANGSMITH_TAGS = "langsmith.span.tags";
 var LANGSMITH_REQUEST_STREAMING = "langsmith.request.streaming";
 var LANGSMITH_REQUEST_HEADERS = "langsmith.request.headers";
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/env.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/env.js
 var globalEnv;
 var isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";
 var isWebWorker = () => typeof globalThis === "object" && globalThis.constructor && globalThis.constructor.name === "DedicatedWorkerGlobalScope";
@@ -978,7 +978,7 @@ function getOtelEnabled() {
   return getEnvironmentVariable("OTEL_ENABLED") === "true" || getLangSmithEnvironmentVariable("OTEL_ENABLED") === "true";
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/otel.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/otel.js
 var MockTracer = class {
   constructor() {
     Object.defineProperty(this, "hasWarned", {
@@ -1084,7 +1084,7 @@ function getDefaultOTLPTracerComponents() {
   return OTELProviderSingleton.getDefaultOTLPTracerComponents();
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/translator.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/translator.js
 var WELL_KNOWN_OPERATION_NAMES = {
   llm: "chat",
   tool: "execute_tool",
@@ -1425,7 +1425,7 @@ var LangSmithToOTELTranslator = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/is-network-error/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/is-network-error/index.js
 var objectToString = Object.prototype.toString;
 var isError = (value) => objectToString.call(value) === "[object Error]";
 var errorMessages = /* @__PURE__ */ new Set([
@@ -1464,7 +1464,7 @@ function isNetworkError(error2) {
   return errorMessages.has(message);
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-retry/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-retry/index.js
 function validateRetries(retries) {
   if (typeof retries === "number") {
     if (retries < 0) {
@@ -1637,11 +1637,11 @@ async function pRetry(input, options = {}) {
   throw new Error("Retry attempts exhausted without throwing an error.");
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-queue.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-queue.js
 var import_p_queue = __toESM(require_dist(), 1);
 var PQueue = "default" in import_p_queue.default ? import_p_queue.default.default : import_p_queue.default;
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/async_caller.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/async_caller.js
 var STATUS_RETRYABLE = [
   408,
   // Request Timeout
@@ -1769,7 +1769,7 @@ var AsyncCaller = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/messages.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/messages.js
 function isLangChainMessage(message) {
   return typeof message?._getType === "function";
 }
@@ -1784,7 +1784,7 @@ function convertLangChainMessageToExample(message) {
   return converted;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/warn.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/warn.js
 var warnedMessages = {};
 function warnOnce(message) {
   if (!warnedMessages[message]) {
@@ -1793,7 +1793,7 @@ function warnOnce(message) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/xxhash/xxhash.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/xxhash/xxhash.js
 var n = (n2) => BigInt(n2);
 var PRIME32_1 = n("0x9E3779B1");
 var PRIME32_2 = n("0x85EBCA77");
@@ -2073,7 +2073,7 @@ function xxh128ToBytes(hash128) {
   return result;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/_uuid.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/_uuid.js
 var UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function assertUuid(str, which) {
   if (!UUID_REGEX.test(str)) {
@@ -2135,7 +2135,7 @@ function nonCryptographicUuid7Deterministic(originalId, key) {
   return bytesToUuid(b);
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/error.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/error.js
 function getInvalidPromptIdentifierMsg(identifier) {
   return `Invalid prompt identifier format: "${identifier}". Expected one of:
   - "prompt-name" (for private prompts)
@@ -2228,7 +2228,7 @@ function isConflictingEndpointsError(err) {
   return typeof err === "object" && err !== null && err.code === ERR_CONFLICTING_ENDPOINTS;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompts.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompts.js
 function parsePromptIdentifier(identifier) {
   if (!identifier || identifier.split("/").length > 2 || identifier.startsWith("/") || identifier.endsWith("/") || identifier.split(":").length > 2) {
     throw new Error(getInvalidPromptIdentifierMsg(identifier));
@@ -2249,7 +2249,7 @@ function parsePromptIdentifier(identifier) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fs.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fs.js
 import * as nodeFs from "node:fs";
 import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
@@ -2290,7 +2290,7 @@ function readFileSync2(filePath) {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompt_cache/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompt_cache/index.js
 function isStale(entry, ttlSeconds) {
   if (ttlSeconds === null) {
     return false;
@@ -2564,7 +2564,7 @@ var PromptCache = class {
 };
 var promptCacheSingleton = new PromptCache();
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/fetch.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/fetch.js
 var DEFAULT_FETCH_IMPLEMENTATION = (...args) => fetch(...args);
 var globalFetchSupportsWebStreaming = void 0;
 var LANGSMITH_FETCH_IMPLEMENTATION_KEY = /* @__PURE__ */ Symbol.for("ls:fetch_implementation");
@@ -2589,7 +2589,7 @@ var _getFetchImplementation = (debug2) => {
   };
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
 var LIMIT_REPLACE_NODE = "[...]";
 var CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
 var arr = [];
@@ -2741,7 +2741,7 @@ function replaceGetterValues(replacer) {
   };
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/client.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/client.js
 function _ensureUTCTimestamp(ts) {
   if (typeof ts === "string" && ts.length > 0 && !ts.includes("Z") && !ts.includes("+") && !ts.includes("-", 10)) {
     return ts + "Z";
@@ -3305,6 +3305,22 @@ var Client = class _Client {
     }
     return outputs;
   }
+  /**
+   * Filter content from new_token events to prevent streaming LLM output
+   * from being uploaded via events.
+   */
+  _filterNewTokenEvents(events) {
+    if (!events || events.length === 0) {
+      return events;
+    }
+    return events.map((event) => {
+      if (event.name === "new_token") {
+        const { kwargs: _, ...rest } = event;
+        return rest;
+      }
+      return event;
+    });
+  }
   async prepareRunCreateOrUpdateInputs(run) {
     const runParams = { ...run };
     if (runParams.inputs !== void 0) {
@@ -3312,6 +3328,9 @@ var Client = class _Client {
     }
     if (runParams.outputs !== void 0) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
+    }
+    if (runParams.events !== void 0) {
+      runParams.events = this._filterNewTokenEvents(runParams.events);
     }
     return runParams;
   }
@@ -4072,6 +4091,9 @@ Context: ${context}`);
     }
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
+    }
+    if (run.events) {
+      run.events = this._filterNewTokenEvents(run.events);
     }
     const data = { ...run, id: runId };
     if (!this._filterForSampling([data], true).length) {
@@ -6933,7 +6955,7 @@ function isExampleCreate(input) {
   return "dataset_id" in input || "dataset_name" in input;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/env.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/env.js
 var isTracingEnabled = (tracingEnabled) => {
   if (tracingEnabled !== void 0) {
     return tracingEnabled;
@@ -6942,11 +6964,11 @@ var isTracingEnabled = (tracingEnabled) => {
   return !!envVars.find((envVar) => getLangSmithEnvironmentVariable(envVar) === "true");
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/constants.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/constants.js
 var _LC_CONTEXT_VARIABLES_KEY = /* @__PURE__ */ Symbol.for("lc:context_variables");
 var _REPLICA_TRACE_ROOTS_KEY = /* @__PURE__ */ Symbol.for("langsmith:replica_trace_roots");
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/context_vars.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/context_vars.js
 function getContextVar(runTree, key) {
   if (_LC_CONTEXT_VARIABLES_KEY in runTree) {
     const contextVars = runTree[_LC_CONTEXT_VARIABLES_KEY];
@@ -6963,13 +6985,13 @@ function setContextVar(runTree, key, value) {
   runTree[_LC_CONTEXT_VARIABLES_KEY] = contextVars;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/project.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/project.js
 var getDefaultProjectName = () => {
   return getLangSmithEnvironmentVariable("PROJECT") ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? // TODO: Deprecate
   "default";
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/run_trees.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/run_trees.js
 var TIMESTAMP_LENGTH = 36;
 var UUID_NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 function getReplicaKey(replica) {
@@ -7870,13 +7892,13 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/uuid.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/uuid.js
 function uuid7() {
   return v7_default();
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/index.js
-var __version__ = "0.5.18";
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/index.js
+var __version__ = "0.5.19";
 
 // dist/logger.js
 import { appendFileSync, mkdirSync as mkdirSync3, statSync, renameSync as renameSync3 } from "node:fs";

--- a/bundle/post-compact.js
+++ b/bundle/post-compact.js
@@ -803,7 +803,7 @@ function v7(options, buf, offset) {
 }
 var v7_default = v7;
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/constants.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/constants.js
 var GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 var GEN_AI_SYSTEM = "gen_ai.system";
 var GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -838,7 +838,7 @@ var LANGSMITH_TAGS = "langsmith.span.tags";
 var LANGSMITH_REQUEST_STREAMING = "langsmith.request.streaming";
 var LANGSMITH_REQUEST_HEADERS = "langsmith.request.headers";
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/env.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/env.js
 var globalEnv;
 var isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";
 var isWebWorker = () => typeof globalThis === "object" && globalThis.constructor && globalThis.constructor.name === "DedicatedWorkerGlobalScope";
@@ -978,7 +978,7 @@ function getOtelEnabled() {
   return getEnvironmentVariable("OTEL_ENABLED") === "true" || getLangSmithEnvironmentVariable("OTEL_ENABLED") === "true";
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/otel.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/otel.js
 var MockTracer = class {
   constructor() {
     Object.defineProperty(this, "hasWarned", {
@@ -1084,7 +1084,7 @@ function getDefaultOTLPTracerComponents() {
   return OTELProviderSingleton.getDefaultOTLPTracerComponents();
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/translator.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/translator.js
 var WELL_KNOWN_OPERATION_NAMES = {
   llm: "chat",
   tool: "execute_tool",
@@ -1425,7 +1425,7 @@ var LangSmithToOTELTranslator = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/is-network-error/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/is-network-error/index.js
 var objectToString = Object.prototype.toString;
 var isError = (value) => objectToString.call(value) === "[object Error]";
 var errorMessages = /* @__PURE__ */ new Set([
@@ -1464,7 +1464,7 @@ function isNetworkError(error2) {
   return errorMessages.has(message);
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-retry/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-retry/index.js
 function validateRetries(retries) {
   if (typeof retries === "number") {
     if (retries < 0) {
@@ -1637,11 +1637,11 @@ async function pRetry(input, options = {}) {
   throw new Error("Retry attempts exhausted without throwing an error.");
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-queue.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-queue.js
 var import_p_queue = __toESM(require_dist(), 1);
 var PQueue = "default" in import_p_queue.default ? import_p_queue.default.default : import_p_queue.default;
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/async_caller.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/async_caller.js
 var STATUS_RETRYABLE = [
   408,
   // Request Timeout
@@ -1769,7 +1769,7 @@ var AsyncCaller = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/messages.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/messages.js
 function isLangChainMessage(message) {
   return typeof message?._getType === "function";
 }
@@ -1784,7 +1784,7 @@ function convertLangChainMessageToExample(message) {
   return converted;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/warn.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/warn.js
 var warnedMessages = {};
 function warnOnce(message) {
   if (!warnedMessages[message]) {
@@ -1793,7 +1793,7 @@ function warnOnce(message) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/xxhash/xxhash.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/xxhash/xxhash.js
 var n = (n2) => BigInt(n2);
 var PRIME32_1 = n("0x9E3779B1");
 var PRIME32_2 = n("0x85EBCA77");
@@ -2073,7 +2073,7 @@ function xxh128ToBytes(hash128) {
   return result;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/_uuid.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/_uuid.js
 var UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function assertUuid(str, which) {
   if (!UUID_REGEX.test(str)) {
@@ -2135,7 +2135,7 @@ function nonCryptographicUuid7Deterministic(originalId, key) {
   return bytesToUuid(b);
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/error.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/error.js
 function getInvalidPromptIdentifierMsg(identifier) {
   return `Invalid prompt identifier format: "${identifier}". Expected one of:
   - "prompt-name" (for private prompts)
@@ -2228,7 +2228,7 @@ function isConflictingEndpointsError(err) {
   return typeof err === "object" && err !== null && err.code === ERR_CONFLICTING_ENDPOINTS;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompts.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompts.js
 function parsePromptIdentifier(identifier) {
   if (!identifier || identifier.split("/").length > 2 || identifier.startsWith("/") || identifier.endsWith("/") || identifier.split(":").length > 2) {
     throw new Error(getInvalidPromptIdentifierMsg(identifier));
@@ -2249,7 +2249,7 @@ function parsePromptIdentifier(identifier) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fs.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fs.js
 import * as nodeFs from "node:fs";
 import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
@@ -2290,7 +2290,7 @@ function readFileSync2(filePath) {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompt_cache/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompt_cache/index.js
 function isStale(entry, ttlSeconds) {
   if (ttlSeconds === null) {
     return false;
@@ -2564,7 +2564,7 @@ var PromptCache = class {
 };
 var promptCacheSingleton = new PromptCache();
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/fetch.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/fetch.js
 var DEFAULT_FETCH_IMPLEMENTATION = (...args) => fetch(...args);
 var globalFetchSupportsWebStreaming = void 0;
 var LANGSMITH_FETCH_IMPLEMENTATION_KEY = /* @__PURE__ */ Symbol.for("ls:fetch_implementation");
@@ -2589,7 +2589,7 @@ var _getFetchImplementation = (debug2) => {
   };
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
 var LIMIT_REPLACE_NODE = "[...]";
 var CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
 var arr = [];
@@ -2741,7 +2741,7 @@ function replaceGetterValues(replacer) {
   };
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/client.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/client.js
 function _ensureUTCTimestamp(ts) {
   if (typeof ts === "string" && ts.length > 0 && !ts.includes("Z") && !ts.includes("+") && !ts.includes("-", 10)) {
     return ts + "Z";
@@ -3305,22 +3305,6 @@ var Client = class _Client {
     }
     return outputs;
   }
-  /**
-   * Filter content from new_token events to prevent streaming LLM output
-   * from being uploaded via events.
-   */
-  _filterNewTokenEvents(events) {
-    if (!events || events.length === 0) {
-      return events;
-    }
-    return events.map((event) => {
-      if (event.name === "new_token") {
-        const { kwargs: _, ...rest } = event;
-        return rest;
-      }
-      return event;
-    });
-  }
   async prepareRunCreateOrUpdateInputs(run) {
     const runParams = { ...run };
     if (runParams.inputs !== void 0) {
@@ -3328,9 +3312,6 @@ var Client = class _Client {
     }
     if (runParams.outputs !== void 0) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
-    }
-    if (runParams.events !== void 0) {
-      runParams.events = this._filterNewTokenEvents(runParams.events);
     }
     return runParams;
   }
@@ -4091,9 +4072,6 @@ Context: ${context}`);
     }
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
-    }
-    if (run.events) {
-      run.events = this._filterNewTokenEvents(run.events);
     }
     const data = { ...run, id: runId };
     if (!this._filterForSampling([data], true).length) {
@@ -6955,7 +6933,7 @@ function isExampleCreate(input) {
   return "dataset_id" in input || "dataset_name" in input;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/env.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/env.js
 var isTracingEnabled = (tracingEnabled) => {
   if (tracingEnabled !== void 0) {
     return tracingEnabled;
@@ -6964,11 +6942,11 @@ var isTracingEnabled = (tracingEnabled) => {
   return !!envVars.find((envVar) => getLangSmithEnvironmentVariable(envVar) === "true");
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/constants.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/constants.js
 var _LC_CONTEXT_VARIABLES_KEY = /* @__PURE__ */ Symbol.for("lc:context_variables");
 var _REPLICA_TRACE_ROOTS_KEY = /* @__PURE__ */ Symbol.for("langsmith:replica_trace_roots");
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/context_vars.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/context_vars.js
 function getContextVar(runTree, key) {
   if (_LC_CONTEXT_VARIABLES_KEY in runTree) {
     const contextVars = runTree[_LC_CONTEXT_VARIABLES_KEY];
@@ -6985,13 +6963,13 @@ function setContextVar(runTree, key, value) {
   runTree[_LC_CONTEXT_VARIABLES_KEY] = contextVars;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/project.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/project.js
 var getDefaultProjectName = () => {
   return getLangSmithEnvironmentVariable("PROJECT") ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? // TODO: Deprecate
   "default";
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/run_trees.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/run_trees.js
 var TIMESTAMP_LENGTH = 36;
 var UUID_NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 function getReplicaKey(replica) {
@@ -7892,13 +7870,13 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/uuid.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/uuid.js
 function uuid7() {
   return v7_default();
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/index.js
-var __version__ = "0.5.19";
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/index.js
+var __version__ = "0.5.18";
 
 // dist/logger.js
 import { appendFileSync, mkdirSync as mkdirSync3, statSync, renameSync as renameSync3 } from "node:fs";
@@ -8026,6 +8004,7 @@ function generateDottedOrderSegment(time, runId) {
 import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -8046,7 +8025,48 @@ function readAnthropicUserId() {
 function readLocalUsername() {
   return userInfo().username;
 }
-function loadConfig() {
+var GIT_PROVIDERS_REGEX = {
+  github: /[@/](?:github\.com)[:/](.+?)(?:\.git)?\s/,
+  gitlab: /[@/](?:gitlab\.com)[:/](.+?)(?:\.git)?\s/,
+  bitbucket: /[@/](?:bitbucket\.org)[:/](.+?)(?:\.git)?\s/,
+  devAzure: /[@/](?:dev\.azure\.com)[:/](.+?)(?:\.git)?\s/
+};
+function parseRepoName(remoteUrl) {
+  for (const [provider, regex] of Object.entries(GIT_PROVIDERS_REGEX)) {
+    const match = remoteUrl.match(regex);
+    if (match)
+      return { provider, name: match[1] };
+  }
+  return void 0;
+}
+function getRepoName(cwd) {
+  try {
+    const output = execSync("git remote -v", { cwd, encoding: "utf-8", timeout: 5e3 });
+    const lines = output.trim().split("\n").filter(Boolean);
+    const remotes = [];
+    for (const line of lines) {
+      const parts = line.split(/\s+/);
+      if (parts.length >= 2 && line.includes("(fetch)")) {
+        remotes.push({ name: parts[0], url: parts[1] });
+      }
+    }
+    const origin = remotes.find((r) => r.name === "origin");
+    if (origin) {
+      const name = parseRepoName(origin.url + " ");
+      if (name)
+        return name;
+    }
+    for (const remote of remotes) {
+      const name = parseRepoName(remote.url + " ");
+      if (name)
+        return name;
+    }
+  } catch {
+  }
+  return void 0;
+}
+function loadConfig(options) {
+  const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
   const project = process.env.CC_LANGSMITH_PROJECT ?? "claude-code";
   const apiBaseUrl = process.env.LANGSMITH_ENDPOINT ?? "https://api.smith.langchain.com";
@@ -8083,7 +8103,13 @@ function loadConfig() {
   if (anthropicUserId) {
     identityMetadata.anthropic_user_id = anthropicUserId;
   }
-  customMetadata = { ...identityMetadata, ...customMetadata };
+  const repoMetadata = {};
+  const repoName = getRepoName(cwd);
+  if (repoName != null) {
+    repoMetadata.repository_name = repoName.name;
+    repoMetadata.repository_provider = repoName.provider;
+  }
+  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,

--- a/bundle/post-tool-use.js
+++ b/bundle/post-tool-use.js
@@ -803,7 +803,7 @@ function v7(options, buf, offset) {
 }
 var v7_default = v7;
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/constants.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/constants.js
 var GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 var GEN_AI_SYSTEM = "gen_ai.system";
 var GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -838,7 +838,7 @@ var LANGSMITH_TAGS = "langsmith.span.tags";
 var LANGSMITH_REQUEST_STREAMING = "langsmith.request.streaming";
 var LANGSMITH_REQUEST_HEADERS = "langsmith.request.headers";
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/env.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/env.js
 var globalEnv;
 var isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";
 var isWebWorker = () => typeof globalThis === "object" && globalThis.constructor && globalThis.constructor.name === "DedicatedWorkerGlobalScope";
@@ -978,7 +978,7 @@ function getOtelEnabled() {
   return getEnvironmentVariable("OTEL_ENABLED") === "true" || getLangSmithEnvironmentVariable("OTEL_ENABLED") === "true";
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/otel.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/otel.js
 var MockTracer = class {
   constructor() {
     Object.defineProperty(this, "hasWarned", {
@@ -1084,7 +1084,7 @@ function getDefaultOTLPTracerComponents() {
   return OTELProviderSingleton.getDefaultOTLPTracerComponents();
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/translator.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/translator.js
 var WELL_KNOWN_OPERATION_NAMES = {
   llm: "chat",
   tool: "execute_tool",
@@ -1425,7 +1425,7 @@ var LangSmithToOTELTranslator = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/is-network-error/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/is-network-error/index.js
 var objectToString = Object.prototype.toString;
 var isError = (value) => objectToString.call(value) === "[object Error]";
 var errorMessages = /* @__PURE__ */ new Set([
@@ -1464,7 +1464,7 @@ function isNetworkError(error2) {
   return errorMessages.has(message);
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-retry/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-retry/index.js
 function validateRetries(retries) {
   if (typeof retries === "number") {
     if (retries < 0) {
@@ -1637,11 +1637,11 @@ async function pRetry(input, options = {}) {
   throw new Error("Retry attempts exhausted without throwing an error.");
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-queue.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-queue.js
 var import_p_queue = __toESM(require_dist(), 1);
 var PQueue = "default" in import_p_queue.default ? import_p_queue.default.default : import_p_queue.default;
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/async_caller.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/async_caller.js
 var STATUS_RETRYABLE = [
   408,
   // Request Timeout
@@ -1769,7 +1769,7 @@ var AsyncCaller = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/messages.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/messages.js
 function isLangChainMessage(message) {
   return typeof message?._getType === "function";
 }
@@ -1784,7 +1784,7 @@ function convertLangChainMessageToExample(message) {
   return converted;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/warn.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/warn.js
 var warnedMessages = {};
 function warnOnce(message) {
   if (!warnedMessages[message]) {
@@ -1793,7 +1793,7 @@ function warnOnce(message) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/xxhash/xxhash.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/xxhash/xxhash.js
 var n = (n2) => BigInt(n2);
 var PRIME32_1 = n("0x9E3779B1");
 var PRIME32_2 = n("0x85EBCA77");
@@ -2073,7 +2073,7 @@ function xxh128ToBytes(hash128) {
   return result;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/_uuid.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/_uuid.js
 var UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function assertUuid(str, which) {
   if (!UUID_REGEX.test(str)) {
@@ -2135,7 +2135,7 @@ function nonCryptographicUuid7Deterministic(originalId, key) {
   return bytesToUuid(b);
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/error.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/error.js
 function getInvalidPromptIdentifierMsg(identifier) {
   return `Invalid prompt identifier format: "${identifier}". Expected one of:
   - "prompt-name" (for private prompts)
@@ -2228,7 +2228,7 @@ function isConflictingEndpointsError(err) {
   return typeof err === "object" && err !== null && err.code === ERR_CONFLICTING_ENDPOINTS;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompts.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompts.js
 function parsePromptIdentifier(identifier) {
   if (!identifier || identifier.split("/").length > 2 || identifier.startsWith("/") || identifier.endsWith("/") || identifier.split(":").length > 2) {
     throw new Error(getInvalidPromptIdentifierMsg(identifier));
@@ -2249,7 +2249,7 @@ function parsePromptIdentifier(identifier) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fs.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fs.js
 import * as nodeFs from "node:fs";
 import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
@@ -2290,7 +2290,7 @@ function readFileSync2(filePath) {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompt_cache/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompt_cache/index.js
 function isStale(entry, ttlSeconds) {
   if (ttlSeconds === null) {
     return false;
@@ -2564,7 +2564,7 @@ var PromptCache = class {
 };
 var promptCacheSingleton = new PromptCache();
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/fetch.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/fetch.js
 var DEFAULT_FETCH_IMPLEMENTATION = (...args) => fetch(...args);
 var globalFetchSupportsWebStreaming = void 0;
 var LANGSMITH_FETCH_IMPLEMENTATION_KEY = /* @__PURE__ */ Symbol.for("ls:fetch_implementation");
@@ -2589,7 +2589,7 @@ var _getFetchImplementation = (debug2) => {
   };
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
 var LIMIT_REPLACE_NODE = "[...]";
 var CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
 var arr = [];
@@ -2741,7 +2741,7 @@ function replaceGetterValues(replacer) {
   };
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/client.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/client.js
 function _ensureUTCTimestamp(ts) {
   if (typeof ts === "string" && ts.length > 0 && !ts.includes("Z") && !ts.includes("+") && !ts.includes("-", 10)) {
     return ts + "Z";
@@ -3305,6 +3305,22 @@ var Client = class _Client {
     }
     return outputs;
   }
+  /**
+   * Filter content from new_token events to prevent streaming LLM output
+   * from being uploaded via events.
+   */
+  _filterNewTokenEvents(events) {
+    if (!events || events.length === 0) {
+      return events;
+    }
+    return events.map((event) => {
+      if (event.name === "new_token") {
+        const { kwargs: _, ...rest } = event;
+        return rest;
+      }
+      return event;
+    });
+  }
   async prepareRunCreateOrUpdateInputs(run) {
     const runParams = { ...run };
     if (runParams.inputs !== void 0) {
@@ -3312,6 +3328,9 @@ var Client = class _Client {
     }
     if (runParams.outputs !== void 0) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
+    }
+    if (runParams.events !== void 0) {
+      runParams.events = this._filterNewTokenEvents(runParams.events);
     }
     return runParams;
   }
@@ -4072,6 +4091,9 @@ Context: ${context}`);
     }
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
+    }
+    if (run.events) {
+      run.events = this._filterNewTokenEvents(run.events);
     }
     const data = { ...run, id: runId };
     if (!this._filterForSampling([data], true).length) {
@@ -6933,7 +6955,7 @@ function isExampleCreate(input) {
   return "dataset_id" in input || "dataset_name" in input;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/env.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/env.js
 var isTracingEnabled = (tracingEnabled) => {
   if (tracingEnabled !== void 0) {
     return tracingEnabled;
@@ -6942,11 +6964,11 @@ var isTracingEnabled = (tracingEnabled) => {
   return !!envVars.find((envVar) => getLangSmithEnvironmentVariable(envVar) === "true");
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/constants.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/constants.js
 var _LC_CONTEXT_VARIABLES_KEY = /* @__PURE__ */ Symbol.for("lc:context_variables");
 var _REPLICA_TRACE_ROOTS_KEY = /* @__PURE__ */ Symbol.for("langsmith:replica_trace_roots");
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/context_vars.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/context_vars.js
 function getContextVar(runTree, key) {
   if (_LC_CONTEXT_VARIABLES_KEY in runTree) {
     const contextVars = runTree[_LC_CONTEXT_VARIABLES_KEY];
@@ -6963,13 +6985,13 @@ function setContextVar(runTree, key, value) {
   runTree[_LC_CONTEXT_VARIABLES_KEY] = contextVars;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/project.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/project.js
 var getDefaultProjectName = () => {
   return getLangSmithEnvironmentVariable("PROJECT") ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? // TODO: Deprecate
   "default";
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/run_trees.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/run_trees.js
 var TIMESTAMP_LENGTH = 36;
 var UUID_NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 function getReplicaKey(replica) {
@@ -7870,13 +7892,13 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/uuid.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/uuid.js
 function uuid7() {
   return v7_default();
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/index.js
-var __version__ = "0.5.18";
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/index.js
+var __version__ = "0.5.19";
 
 // dist/logger.js
 import { appendFileSync, mkdirSync as mkdirSync3, statSync, renameSync as renameSync3 } from "node:fs";

--- a/bundle/post-tool-use.js
+++ b/bundle/post-tool-use.js
@@ -803,7 +803,7 @@ function v7(options, buf, offset) {
 }
 var v7_default = v7;
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/constants.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/constants.js
 var GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 var GEN_AI_SYSTEM = "gen_ai.system";
 var GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -838,7 +838,7 @@ var LANGSMITH_TAGS = "langsmith.span.tags";
 var LANGSMITH_REQUEST_STREAMING = "langsmith.request.streaming";
 var LANGSMITH_REQUEST_HEADERS = "langsmith.request.headers";
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/env.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/env.js
 var globalEnv;
 var isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";
 var isWebWorker = () => typeof globalThis === "object" && globalThis.constructor && globalThis.constructor.name === "DedicatedWorkerGlobalScope";
@@ -978,7 +978,7 @@ function getOtelEnabled() {
   return getEnvironmentVariable("OTEL_ENABLED") === "true" || getLangSmithEnvironmentVariable("OTEL_ENABLED") === "true";
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/otel.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/otel.js
 var MockTracer = class {
   constructor() {
     Object.defineProperty(this, "hasWarned", {
@@ -1084,7 +1084,7 @@ function getDefaultOTLPTracerComponents() {
   return OTELProviderSingleton.getDefaultOTLPTracerComponents();
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/translator.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/translator.js
 var WELL_KNOWN_OPERATION_NAMES = {
   llm: "chat",
   tool: "execute_tool",
@@ -1425,7 +1425,7 @@ var LangSmithToOTELTranslator = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/is-network-error/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/is-network-error/index.js
 var objectToString = Object.prototype.toString;
 var isError = (value) => objectToString.call(value) === "[object Error]";
 var errorMessages = /* @__PURE__ */ new Set([
@@ -1464,7 +1464,7 @@ function isNetworkError(error2) {
   return errorMessages.has(message);
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-retry/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-retry/index.js
 function validateRetries(retries) {
   if (typeof retries === "number") {
     if (retries < 0) {
@@ -1637,11 +1637,11 @@ async function pRetry(input, options = {}) {
   throw new Error("Retry attempts exhausted without throwing an error.");
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-queue.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-queue.js
 var import_p_queue = __toESM(require_dist(), 1);
 var PQueue = "default" in import_p_queue.default ? import_p_queue.default.default : import_p_queue.default;
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/async_caller.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/async_caller.js
 var STATUS_RETRYABLE = [
   408,
   // Request Timeout
@@ -1769,7 +1769,7 @@ var AsyncCaller = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/messages.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/messages.js
 function isLangChainMessage(message) {
   return typeof message?._getType === "function";
 }
@@ -1784,7 +1784,7 @@ function convertLangChainMessageToExample(message) {
   return converted;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/warn.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/warn.js
 var warnedMessages = {};
 function warnOnce(message) {
   if (!warnedMessages[message]) {
@@ -1793,7 +1793,7 @@ function warnOnce(message) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/xxhash/xxhash.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/xxhash/xxhash.js
 var n = (n2) => BigInt(n2);
 var PRIME32_1 = n("0x9E3779B1");
 var PRIME32_2 = n("0x85EBCA77");
@@ -2073,7 +2073,7 @@ function xxh128ToBytes(hash128) {
   return result;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/_uuid.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/_uuid.js
 var UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function assertUuid(str, which) {
   if (!UUID_REGEX.test(str)) {
@@ -2135,7 +2135,7 @@ function nonCryptographicUuid7Deterministic(originalId, key) {
   return bytesToUuid(b);
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/error.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/error.js
 function getInvalidPromptIdentifierMsg(identifier) {
   return `Invalid prompt identifier format: "${identifier}". Expected one of:
   - "prompt-name" (for private prompts)
@@ -2228,7 +2228,7 @@ function isConflictingEndpointsError(err) {
   return typeof err === "object" && err !== null && err.code === ERR_CONFLICTING_ENDPOINTS;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompts.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompts.js
 function parsePromptIdentifier(identifier) {
   if (!identifier || identifier.split("/").length > 2 || identifier.startsWith("/") || identifier.endsWith("/") || identifier.split(":").length > 2) {
     throw new Error(getInvalidPromptIdentifierMsg(identifier));
@@ -2249,7 +2249,7 @@ function parsePromptIdentifier(identifier) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fs.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fs.js
 import * as nodeFs from "node:fs";
 import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
@@ -2290,7 +2290,7 @@ function readFileSync2(filePath) {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompt_cache/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompt_cache/index.js
 function isStale(entry, ttlSeconds) {
   if (ttlSeconds === null) {
     return false;
@@ -2564,7 +2564,7 @@ var PromptCache = class {
 };
 var promptCacheSingleton = new PromptCache();
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/fetch.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/fetch.js
 var DEFAULT_FETCH_IMPLEMENTATION = (...args) => fetch(...args);
 var globalFetchSupportsWebStreaming = void 0;
 var LANGSMITH_FETCH_IMPLEMENTATION_KEY = /* @__PURE__ */ Symbol.for("ls:fetch_implementation");
@@ -2589,7 +2589,7 @@ var _getFetchImplementation = (debug2) => {
   };
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
 var LIMIT_REPLACE_NODE = "[...]";
 var CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
 var arr = [];
@@ -2741,7 +2741,7 @@ function replaceGetterValues(replacer) {
   };
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/client.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/client.js
 function _ensureUTCTimestamp(ts) {
   if (typeof ts === "string" && ts.length > 0 && !ts.includes("Z") && !ts.includes("+") && !ts.includes("-", 10)) {
     return ts + "Z";
@@ -3305,22 +3305,6 @@ var Client = class _Client {
     }
     return outputs;
   }
-  /**
-   * Filter content from new_token events to prevent streaming LLM output
-   * from being uploaded via events.
-   */
-  _filterNewTokenEvents(events) {
-    if (!events || events.length === 0) {
-      return events;
-    }
-    return events.map((event) => {
-      if (event.name === "new_token") {
-        const { kwargs: _, ...rest } = event;
-        return rest;
-      }
-      return event;
-    });
-  }
   async prepareRunCreateOrUpdateInputs(run) {
     const runParams = { ...run };
     if (runParams.inputs !== void 0) {
@@ -3328,9 +3312,6 @@ var Client = class _Client {
     }
     if (runParams.outputs !== void 0) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
-    }
-    if (runParams.events !== void 0) {
-      runParams.events = this._filterNewTokenEvents(runParams.events);
     }
     return runParams;
   }
@@ -4091,9 +4072,6 @@ Context: ${context}`);
     }
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
-    }
-    if (run.events) {
-      run.events = this._filterNewTokenEvents(run.events);
     }
     const data = { ...run, id: runId };
     if (!this._filterForSampling([data], true).length) {
@@ -6955,7 +6933,7 @@ function isExampleCreate(input) {
   return "dataset_id" in input || "dataset_name" in input;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/env.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/env.js
 var isTracingEnabled = (tracingEnabled) => {
   if (tracingEnabled !== void 0) {
     return tracingEnabled;
@@ -6964,11 +6942,11 @@ var isTracingEnabled = (tracingEnabled) => {
   return !!envVars.find((envVar) => getLangSmithEnvironmentVariable(envVar) === "true");
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/constants.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/constants.js
 var _LC_CONTEXT_VARIABLES_KEY = /* @__PURE__ */ Symbol.for("lc:context_variables");
 var _REPLICA_TRACE_ROOTS_KEY = /* @__PURE__ */ Symbol.for("langsmith:replica_trace_roots");
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/context_vars.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/context_vars.js
 function getContextVar(runTree, key) {
   if (_LC_CONTEXT_VARIABLES_KEY in runTree) {
     const contextVars = runTree[_LC_CONTEXT_VARIABLES_KEY];
@@ -6985,13 +6963,13 @@ function setContextVar(runTree, key, value) {
   runTree[_LC_CONTEXT_VARIABLES_KEY] = contextVars;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/project.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/project.js
 var getDefaultProjectName = () => {
   return getLangSmithEnvironmentVariable("PROJECT") ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? // TODO: Deprecate
   "default";
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/run_trees.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/run_trees.js
 var TIMESTAMP_LENGTH = 36;
 var UUID_NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 function getReplicaKey(replica) {
@@ -7892,13 +7870,13 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/uuid.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/uuid.js
 function uuid7() {
   return v7_default();
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/index.js
-var __version__ = "0.5.19";
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/index.js
+var __version__ = "0.5.18";
 
 // dist/logger.js
 import { appendFileSync, mkdirSync as mkdirSync3, statSync, renameSync as renameSync3 } from "node:fs";
@@ -8034,6 +8012,7 @@ function generateDottedOrderSegment(time, runId) {
 import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -8054,7 +8033,48 @@ function readAnthropicUserId() {
 function readLocalUsername() {
   return userInfo().username;
 }
-function loadConfig() {
+var GIT_PROVIDERS_REGEX = {
+  github: /[@/](?:github\.com)[:/](.+?)(?:\.git)?\s/,
+  gitlab: /[@/](?:gitlab\.com)[:/](.+?)(?:\.git)?\s/,
+  bitbucket: /[@/](?:bitbucket\.org)[:/](.+?)(?:\.git)?\s/,
+  devAzure: /[@/](?:dev\.azure\.com)[:/](.+?)(?:\.git)?\s/
+};
+function parseRepoName(remoteUrl) {
+  for (const [provider, regex] of Object.entries(GIT_PROVIDERS_REGEX)) {
+    const match = remoteUrl.match(regex);
+    if (match)
+      return { provider, name: match[1] };
+  }
+  return void 0;
+}
+function getRepoName(cwd) {
+  try {
+    const output = execSync("git remote -v", { cwd, encoding: "utf-8", timeout: 5e3 });
+    const lines = output.trim().split("\n").filter(Boolean);
+    const remotes = [];
+    for (const line of lines) {
+      const parts = line.split(/\s+/);
+      if (parts.length >= 2 && line.includes("(fetch)")) {
+        remotes.push({ name: parts[0], url: parts[1] });
+      }
+    }
+    const origin = remotes.find((r) => r.name === "origin");
+    if (origin) {
+      const name = parseRepoName(origin.url + " ");
+      if (name)
+        return name;
+    }
+    for (const remote of remotes) {
+      const name = parseRepoName(remote.url + " ");
+      if (name)
+        return name;
+    }
+  } catch {
+  }
+  return void 0;
+}
+function loadConfig(options) {
+  const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
   const project = process.env.CC_LANGSMITH_PROJECT ?? "claude-code";
   const apiBaseUrl = process.env.LANGSMITH_ENDPOINT ?? "https://api.smith.langchain.com";
@@ -8091,7 +8111,13 @@ function loadConfig() {
   if (anthropicUserId) {
     identityMetadata.anthropic_user_id = anthropicUserId;
   }
-  customMetadata = { ...identityMetadata, ...customMetadata };
+  const repoMetadata = {};
+  const repoName = getRepoName(cwd);
+  if (repoName != null) {
+    repoMetadata.repository_name = repoName.name;
+    repoMetadata.repository_provider = repoName.provider;
+  }
+  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,

--- a/bundle/pre-compact.js
+++ b/bundle/pre-compact.js
@@ -103,6 +103,7 @@ var SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 import { readFileSync as readFileSync2 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -123,7 +124,48 @@ function readAnthropicUserId() {
 function readLocalUsername() {
   return userInfo().username;
 }
-function loadConfig() {
+var GIT_PROVIDERS_REGEX = {
+  github: /[@/](?:github\.com)[:/](.+?)(?:\.git)?\s/,
+  gitlab: /[@/](?:gitlab\.com)[:/](.+?)(?:\.git)?\s/,
+  bitbucket: /[@/](?:bitbucket\.org)[:/](.+?)(?:\.git)?\s/,
+  devAzure: /[@/](?:dev\.azure\.com)[:/](.+?)(?:\.git)?\s/
+};
+function parseRepoName(remoteUrl) {
+  for (const [provider, regex] of Object.entries(GIT_PROVIDERS_REGEX)) {
+    const match = remoteUrl.match(regex);
+    if (match)
+      return { provider, name: match[1] };
+  }
+  return void 0;
+}
+function getRepoName(cwd) {
+  try {
+    const output = execSync("git remote -v", { cwd, encoding: "utf-8", timeout: 5e3 });
+    const lines = output.trim().split("\n").filter(Boolean);
+    const remotes = [];
+    for (const line of lines) {
+      const parts = line.split(/\s+/);
+      if (parts.length >= 2 && line.includes("(fetch)")) {
+        remotes.push({ name: parts[0], url: parts[1] });
+      }
+    }
+    const origin = remotes.find((r) => r.name === "origin");
+    if (origin) {
+      const name = parseRepoName(origin.url + " ");
+      if (name)
+        return name;
+    }
+    for (const remote of remotes) {
+      const name = parseRepoName(remote.url + " ");
+      if (name)
+        return name;
+    }
+  } catch {
+  }
+  return void 0;
+}
+function loadConfig(options) {
+  const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
   const project = process.env.CC_LANGSMITH_PROJECT ?? "claude-code";
   const apiBaseUrl = process.env.LANGSMITH_ENDPOINT ?? "https://api.smith.langchain.com";
@@ -160,7 +202,13 @@ function loadConfig() {
   if (anthropicUserId) {
     identityMetadata.anthropic_user_id = anthropicUserId;
   }
-  customMetadata = { ...identityMetadata, ...customMetadata };
+  const repoMetadata = {};
+  const repoName = getRepoName(cwd);
+  if (repoName != null) {
+    repoMetadata.repository_name = repoName.name;
+    repoMetadata.repository_provider = repoName.provider;
+  }
+  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,

--- a/bundle/pre-tool-use.js
+++ b/bundle/pre-tool-use.js
@@ -103,6 +103,7 @@ var SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 import { readFileSync as readFileSync2 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -123,7 +124,48 @@ function readAnthropicUserId() {
 function readLocalUsername() {
   return userInfo().username;
 }
-function loadConfig() {
+var GIT_PROVIDERS_REGEX = {
+  github: /[@/](?:github\.com)[:/](.+?)(?:\.git)?\s/,
+  gitlab: /[@/](?:gitlab\.com)[:/](.+?)(?:\.git)?\s/,
+  bitbucket: /[@/](?:bitbucket\.org)[:/](.+?)(?:\.git)?\s/,
+  devAzure: /[@/](?:dev\.azure\.com)[:/](.+?)(?:\.git)?\s/
+};
+function parseRepoName(remoteUrl) {
+  for (const [provider, regex] of Object.entries(GIT_PROVIDERS_REGEX)) {
+    const match = remoteUrl.match(regex);
+    if (match)
+      return { provider, name: match[1] };
+  }
+  return void 0;
+}
+function getRepoName(cwd) {
+  try {
+    const output = execSync("git remote -v", { cwd, encoding: "utf-8", timeout: 5e3 });
+    const lines = output.trim().split("\n").filter(Boolean);
+    const remotes = [];
+    for (const line of lines) {
+      const parts = line.split(/\s+/);
+      if (parts.length >= 2 && line.includes("(fetch)")) {
+        remotes.push({ name: parts[0], url: parts[1] });
+      }
+    }
+    const origin = remotes.find((r) => r.name === "origin");
+    if (origin) {
+      const name = parseRepoName(origin.url + " ");
+      if (name)
+        return name;
+    }
+    for (const remote of remotes) {
+      const name = parseRepoName(remote.url + " ");
+      if (name)
+        return name;
+    }
+  } catch {
+  }
+  return void 0;
+}
+function loadConfig(options) {
+  const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
   const project = process.env.CC_LANGSMITH_PROJECT ?? "claude-code";
   const apiBaseUrl = process.env.LANGSMITH_ENDPOINT ?? "https://api.smith.langchain.com";
@@ -160,7 +202,13 @@ function loadConfig() {
   if (anthropicUserId) {
     identityMetadata.anthropic_user_id = anthropicUserId;
   }
-  customMetadata = { ...identityMetadata, ...customMetadata };
+  const repoMetadata = {};
+  const repoName = getRepoName(cwd);
+  if (repoName != null) {
+    repoMetadata.repository_name = repoName.name;
+    repoMetadata.repository_provider = repoName.provider;
+  }
+  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -846,7 +846,7 @@ function v7(options, buf, offset) {
 }
 var v7_default = v7;
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/constants.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/constants.js
 var GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 var GEN_AI_SYSTEM = "gen_ai.system";
 var GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -881,7 +881,7 @@ var LANGSMITH_TAGS = "langsmith.span.tags";
 var LANGSMITH_REQUEST_STREAMING = "langsmith.request.streaming";
 var LANGSMITH_REQUEST_HEADERS = "langsmith.request.headers";
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/env.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/env.js
 var globalEnv;
 var isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";
 var isWebWorker = () => typeof globalThis === "object" && globalThis.constructor && globalThis.constructor.name === "DedicatedWorkerGlobalScope";
@@ -1021,7 +1021,7 @@ function getOtelEnabled() {
   return getEnvironmentVariable("OTEL_ENABLED") === "true" || getLangSmithEnvironmentVariable("OTEL_ENABLED") === "true";
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/otel.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/otel.js
 var MockTracer = class {
   constructor() {
     Object.defineProperty(this, "hasWarned", {
@@ -1127,7 +1127,7 @@ function getDefaultOTLPTracerComponents() {
   return OTELProviderSingleton.getDefaultOTLPTracerComponents();
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/translator.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/translator.js
 var WELL_KNOWN_OPERATION_NAMES = {
   llm: "chat",
   tool: "execute_tool",
@@ -1468,7 +1468,7 @@ var LangSmithToOTELTranslator = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/is-network-error/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/is-network-error/index.js
 var objectToString = Object.prototype.toString;
 var isError = (value) => objectToString.call(value) === "[object Error]";
 var errorMessages = /* @__PURE__ */ new Set([
@@ -1507,7 +1507,7 @@ function isNetworkError(error2) {
   return errorMessages.has(message);
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-retry/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-retry/index.js
 function validateRetries(retries) {
   if (typeof retries === "number") {
     if (retries < 0) {
@@ -1680,11 +1680,11 @@ async function pRetry(input, options = {}) {
   throw new Error("Retry attempts exhausted without throwing an error.");
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-queue.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-queue.js
 var import_p_queue = __toESM(require_dist(), 1);
 var PQueue = "default" in import_p_queue.default ? import_p_queue.default.default : import_p_queue.default;
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/async_caller.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/async_caller.js
 var STATUS_RETRYABLE = [
   408,
   // Request Timeout
@@ -1812,7 +1812,7 @@ var AsyncCaller = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/messages.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/messages.js
 function isLangChainMessage(message) {
   return typeof message?._getType === "function";
 }
@@ -1827,7 +1827,7 @@ function convertLangChainMessageToExample(message) {
   return converted;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/warn.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/warn.js
 var warnedMessages = {};
 function warnOnce(message) {
   if (!warnedMessages[message]) {
@@ -1836,7 +1836,7 @@ function warnOnce(message) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/xxhash/xxhash.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/xxhash/xxhash.js
 var n = (n2) => BigInt(n2);
 var PRIME32_1 = n("0x9E3779B1");
 var PRIME32_2 = n("0x85EBCA77");
@@ -2116,7 +2116,7 @@ function xxh128ToBytes(hash128) {
   return result;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/_uuid.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/_uuid.js
 var UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function assertUuid(str, which) {
   if (!UUID_REGEX.test(str)) {
@@ -2178,7 +2178,7 @@ function nonCryptographicUuid7Deterministic(originalId, key) {
   return bytesToUuid(b);
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/error.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/error.js
 function getInvalidPromptIdentifierMsg(identifier) {
   return `Invalid prompt identifier format: "${identifier}". Expected one of:
   - "prompt-name" (for private prompts)
@@ -2271,7 +2271,7 @@ function isConflictingEndpointsError(err) {
   return typeof err === "object" && err !== null && err.code === ERR_CONFLICTING_ENDPOINTS;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompts.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompts.js
 function parsePromptIdentifier(identifier) {
   if (!identifier || identifier.split("/").length > 2 || identifier.startsWith("/") || identifier.endsWith("/") || identifier.split(":").length > 2) {
     throw new Error(getInvalidPromptIdentifierMsg(identifier));
@@ -2292,7 +2292,7 @@ function parsePromptIdentifier(identifier) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fs.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fs.js
 import * as nodeFs from "node:fs";
 import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
@@ -2333,7 +2333,7 @@ function readFileSync2(filePath) {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompt_cache/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompt_cache/index.js
 function isStale(entry, ttlSeconds) {
   if (ttlSeconds === null) {
     return false;
@@ -2607,7 +2607,7 @@ var PromptCache = class {
 };
 var promptCacheSingleton = new PromptCache();
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/fetch.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/fetch.js
 var DEFAULT_FETCH_IMPLEMENTATION = (...args) => fetch(...args);
 var globalFetchSupportsWebStreaming = void 0;
 var LANGSMITH_FETCH_IMPLEMENTATION_KEY = /* @__PURE__ */ Symbol.for("ls:fetch_implementation");
@@ -2632,7 +2632,7 @@ var _getFetchImplementation = (debug2) => {
   };
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
 var LIMIT_REPLACE_NODE = "[...]";
 var CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
 var arr = [];
@@ -2784,7 +2784,7 @@ function replaceGetterValues(replacer) {
   };
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/client.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/client.js
 function _ensureUTCTimestamp(ts) {
   if (typeof ts === "string" && ts.length > 0 && !ts.includes("Z") && !ts.includes("+") && !ts.includes("-", 10)) {
     return ts + "Z";
@@ -3348,6 +3348,22 @@ var Client = class _Client {
     }
     return outputs;
   }
+  /**
+   * Filter content from new_token events to prevent streaming LLM output
+   * from being uploaded via events.
+   */
+  _filterNewTokenEvents(events) {
+    if (!events || events.length === 0) {
+      return events;
+    }
+    return events.map((event) => {
+      if (event.name === "new_token") {
+        const { kwargs: _, ...rest } = event;
+        return rest;
+      }
+      return event;
+    });
+  }
   async prepareRunCreateOrUpdateInputs(run) {
     const runParams = { ...run };
     if (runParams.inputs !== void 0) {
@@ -3355,6 +3371,9 @@ var Client = class _Client {
     }
     if (runParams.outputs !== void 0) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
+    }
+    if (runParams.events !== void 0) {
+      runParams.events = this._filterNewTokenEvents(runParams.events);
     }
     return runParams;
   }
@@ -4115,6 +4134,9 @@ Context: ${context}`);
     }
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
+    }
+    if (run.events) {
+      run.events = this._filterNewTokenEvents(run.events);
     }
     const data = { ...run, id: runId };
     if (!this._filterForSampling([data], true).length) {
@@ -6976,7 +6998,7 @@ function isExampleCreate(input) {
   return "dataset_id" in input || "dataset_name" in input;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/env.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/env.js
 var isTracingEnabled = (tracingEnabled) => {
   if (tracingEnabled !== void 0) {
     return tracingEnabled;
@@ -6985,11 +7007,11 @@ var isTracingEnabled = (tracingEnabled) => {
   return !!envVars.find((envVar) => getLangSmithEnvironmentVariable(envVar) === "true");
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/constants.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/constants.js
 var _LC_CONTEXT_VARIABLES_KEY = /* @__PURE__ */ Symbol.for("lc:context_variables");
 var _REPLICA_TRACE_ROOTS_KEY = /* @__PURE__ */ Symbol.for("langsmith:replica_trace_roots");
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/context_vars.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/context_vars.js
 function getContextVar(runTree, key) {
   if (_LC_CONTEXT_VARIABLES_KEY in runTree) {
     const contextVars = runTree[_LC_CONTEXT_VARIABLES_KEY];
@@ -7006,13 +7028,13 @@ function setContextVar(runTree, key, value) {
   runTree[_LC_CONTEXT_VARIABLES_KEY] = contextVars;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/project.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/project.js
 var getDefaultProjectName = () => {
   return getLangSmithEnvironmentVariable("PROJECT") ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? // TODO: Deprecate
   "default";
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/run_trees.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/run_trees.js
 var TIMESTAMP_LENGTH = 36;
 var UUID_NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 function getReplicaKey(replica) {
@@ -7913,13 +7935,13 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/uuid.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/uuid.js
 function uuid7() {
   return v7_default();
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/index.js
-var __version__ = "0.5.18";
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/index.js
+var __version__ = "0.5.19";
 
 // dist/transcript.js
 import { readFileSync as readFileSync3, statSync as statSync2, openSync, readSync, closeSync } from "node:fs";

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -846,7 +846,7 @@ function v7(options, buf, offset) {
 }
 var v7_default = v7;
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/constants.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/constants.js
 var GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 var GEN_AI_SYSTEM = "gen_ai.system";
 var GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -881,7 +881,7 @@ var LANGSMITH_TAGS = "langsmith.span.tags";
 var LANGSMITH_REQUEST_STREAMING = "langsmith.request.streaming";
 var LANGSMITH_REQUEST_HEADERS = "langsmith.request.headers";
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/env.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/env.js
 var globalEnv;
 var isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";
 var isWebWorker = () => typeof globalThis === "object" && globalThis.constructor && globalThis.constructor.name === "DedicatedWorkerGlobalScope";
@@ -1021,7 +1021,7 @@ function getOtelEnabled() {
   return getEnvironmentVariable("OTEL_ENABLED") === "true" || getLangSmithEnvironmentVariable("OTEL_ENABLED") === "true";
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/otel.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/otel.js
 var MockTracer = class {
   constructor() {
     Object.defineProperty(this, "hasWarned", {
@@ -1127,7 +1127,7 @@ function getDefaultOTLPTracerComponents() {
   return OTELProviderSingleton.getDefaultOTLPTracerComponents();
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/translator.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/translator.js
 var WELL_KNOWN_OPERATION_NAMES = {
   llm: "chat",
   tool: "execute_tool",
@@ -1468,7 +1468,7 @@ var LangSmithToOTELTranslator = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/is-network-error/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/is-network-error/index.js
 var objectToString = Object.prototype.toString;
 var isError = (value) => objectToString.call(value) === "[object Error]";
 var errorMessages = /* @__PURE__ */ new Set([
@@ -1507,7 +1507,7 @@ function isNetworkError(error2) {
   return errorMessages.has(message);
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-retry/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-retry/index.js
 function validateRetries(retries) {
   if (typeof retries === "number") {
     if (retries < 0) {
@@ -1680,11 +1680,11 @@ async function pRetry(input, options = {}) {
   throw new Error("Retry attempts exhausted without throwing an error.");
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-queue.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-queue.js
 var import_p_queue = __toESM(require_dist(), 1);
 var PQueue = "default" in import_p_queue.default ? import_p_queue.default.default : import_p_queue.default;
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/async_caller.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/async_caller.js
 var STATUS_RETRYABLE = [
   408,
   // Request Timeout
@@ -1812,7 +1812,7 @@ var AsyncCaller = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/messages.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/messages.js
 function isLangChainMessage(message) {
   return typeof message?._getType === "function";
 }
@@ -1827,7 +1827,7 @@ function convertLangChainMessageToExample(message) {
   return converted;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/warn.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/warn.js
 var warnedMessages = {};
 function warnOnce(message) {
   if (!warnedMessages[message]) {
@@ -1836,7 +1836,7 @@ function warnOnce(message) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/xxhash/xxhash.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/xxhash/xxhash.js
 var n = (n2) => BigInt(n2);
 var PRIME32_1 = n("0x9E3779B1");
 var PRIME32_2 = n("0x85EBCA77");
@@ -2116,7 +2116,7 @@ function xxh128ToBytes(hash128) {
   return result;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/_uuid.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/_uuid.js
 var UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function assertUuid(str, which) {
   if (!UUID_REGEX.test(str)) {
@@ -2178,7 +2178,7 @@ function nonCryptographicUuid7Deterministic(originalId, key) {
   return bytesToUuid(b);
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/error.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/error.js
 function getInvalidPromptIdentifierMsg(identifier) {
   return `Invalid prompt identifier format: "${identifier}". Expected one of:
   - "prompt-name" (for private prompts)
@@ -2271,7 +2271,7 @@ function isConflictingEndpointsError(err) {
   return typeof err === "object" && err !== null && err.code === ERR_CONFLICTING_ENDPOINTS;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompts.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompts.js
 function parsePromptIdentifier(identifier) {
   if (!identifier || identifier.split("/").length > 2 || identifier.startsWith("/") || identifier.endsWith("/") || identifier.split(":").length > 2) {
     throw new Error(getInvalidPromptIdentifierMsg(identifier));
@@ -2292,7 +2292,7 @@ function parsePromptIdentifier(identifier) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fs.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fs.js
 import * as nodeFs from "node:fs";
 import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
@@ -2333,7 +2333,7 @@ function readFileSync2(filePath) {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompt_cache/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompt_cache/index.js
 function isStale(entry, ttlSeconds) {
   if (ttlSeconds === null) {
     return false;
@@ -2607,7 +2607,7 @@ var PromptCache = class {
 };
 var promptCacheSingleton = new PromptCache();
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/fetch.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/fetch.js
 var DEFAULT_FETCH_IMPLEMENTATION = (...args) => fetch(...args);
 var globalFetchSupportsWebStreaming = void 0;
 var LANGSMITH_FETCH_IMPLEMENTATION_KEY = /* @__PURE__ */ Symbol.for("ls:fetch_implementation");
@@ -2632,7 +2632,7 @@ var _getFetchImplementation = (debug2) => {
   };
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
 var LIMIT_REPLACE_NODE = "[...]";
 var CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
 var arr = [];
@@ -2784,7 +2784,7 @@ function replaceGetterValues(replacer) {
   };
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/client.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/client.js
 function _ensureUTCTimestamp(ts) {
   if (typeof ts === "string" && ts.length > 0 && !ts.includes("Z") && !ts.includes("+") && !ts.includes("-", 10)) {
     return ts + "Z";
@@ -3348,22 +3348,6 @@ var Client = class _Client {
     }
     return outputs;
   }
-  /**
-   * Filter content from new_token events to prevent streaming LLM output
-   * from being uploaded via events.
-   */
-  _filterNewTokenEvents(events) {
-    if (!events || events.length === 0) {
-      return events;
-    }
-    return events.map((event) => {
-      if (event.name === "new_token") {
-        const { kwargs: _, ...rest } = event;
-        return rest;
-      }
-      return event;
-    });
-  }
   async prepareRunCreateOrUpdateInputs(run) {
     const runParams = { ...run };
     if (runParams.inputs !== void 0) {
@@ -3371,9 +3355,6 @@ var Client = class _Client {
     }
     if (runParams.outputs !== void 0) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
-    }
-    if (runParams.events !== void 0) {
-      runParams.events = this._filterNewTokenEvents(runParams.events);
     }
     return runParams;
   }
@@ -4134,9 +4115,6 @@ Context: ${context}`);
     }
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
-    }
-    if (run.events) {
-      run.events = this._filterNewTokenEvents(run.events);
     }
     const data = { ...run, id: runId };
     if (!this._filterForSampling([data], true).length) {
@@ -6998,7 +6976,7 @@ function isExampleCreate(input) {
   return "dataset_id" in input || "dataset_name" in input;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/env.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/env.js
 var isTracingEnabled = (tracingEnabled) => {
   if (tracingEnabled !== void 0) {
     return tracingEnabled;
@@ -7007,11 +6985,11 @@ var isTracingEnabled = (tracingEnabled) => {
   return !!envVars.find((envVar) => getLangSmithEnvironmentVariable(envVar) === "true");
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/constants.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/constants.js
 var _LC_CONTEXT_VARIABLES_KEY = /* @__PURE__ */ Symbol.for("lc:context_variables");
 var _REPLICA_TRACE_ROOTS_KEY = /* @__PURE__ */ Symbol.for("langsmith:replica_trace_roots");
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/context_vars.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/context_vars.js
 function getContextVar(runTree, key) {
   if (_LC_CONTEXT_VARIABLES_KEY in runTree) {
     const contextVars = runTree[_LC_CONTEXT_VARIABLES_KEY];
@@ -7028,13 +7006,13 @@ function setContextVar(runTree, key, value) {
   runTree[_LC_CONTEXT_VARIABLES_KEY] = contextVars;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/project.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/project.js
 var getDefaultProjectName = () => {
   return getLangSmithEnvironmentVariable("PROJECT") ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? // TODO: Deprecate
   "default";
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/run_trees.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/run_trees.js
 var TIMESTAMP_LENGTH = 36;
 var UUID_NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 function getReplicaKey(replica) {
@@ -7935,13 +7913,13 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/uuid.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/uuid.js
 function uuid7() {
   return v7_default();
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/index.js
-var __version__ = "0.5.19";
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/index.js
+var __version__ = "0.5.18";
 
 // dist/transcript.js
 import { readFileSync as readFileSync3, statSync as statSync2, openSync, readSync, closeSync } from "node:fs";
@@ -8649,6 +8627,7 @@ async function tracePendingSubagents(options) {
 import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -8669,7 +8648,48 @@ function readAnthropicUserId() {
 function readLocalUsername() {
   return userInfo().username;
 }
-function loadConfig() {
+var GIT_PROVIDERS_REGEX = {
+  github: /[@/](?:github\.com)[:/](.+?)(?:\.git)?\s/,
+  gitlab: /[@/](?:gitlab\.com)[:/](.+?)(?:\.git)?\s/,
+  bitbucket: /[@/](?:bitbucket\.org)[:/](.+?)(?:\.git)?\s/,
+  devAzure: /[@/](?:dev\.azure\.com)[:/](.+?)(?:\.git)?\s/
+};
+function parseRepoName(remoteUrl) {
+  for (const [provider, regex] of Object.entries(GIT_PROVIDERS_REGEX)) {
+    const match = remoteUrl.match(regex);
+    if (match)
+      return { provider, name: match[1] };
+  }
+  return void 0;
+}
+function getRepoName(cwd) {
+  try {
+    const output = execSync("git remote -v", { cwd, encoding: "utf-8", timeout: 5e3 });
+    const lines = output.trim().split("\n").filter(Boolean);
+    const remotes = [];
+    for (const line of lines) {
+      const parts = line.split(/\s+/);
+      if (parts.length >= 2 && line.includes("(fetch)")) {
+        remotes.push({ name: parts[0], url: parts[1] });
+      }
+    }
+    const origin = remotes.find((r) => r.name === "origin");
+    if (origin) {
+      const name = parseRepoName(origin.url + " ");
+      if (name)
+        return name;
+    }
+    for (const remote of remotes) {
+      const name = parseRepoName(remote.url + " ");
+      if (name)
+        return name;
+    }
+  } catch {
+  }
+  return void 0;
+}
+function loadConfig(options) {
+  const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
   const project = process.env.CC_LANGSMITH_PROJECT ?? "claude-code";
   const apiBaseUrl = process.env.LANGSMITH_ENDPOINT ?? "https://api.smith.langchain.com";
@@ -8706,7 +8726,13 @@ function loadConfig() {
   if (anthropicUserId) {
     identityMetadata.anthropic_user_id = anthropicUserId;
   }
-  customMetadata = { ...identityMetadata, ...customMetadata };
+  const repoMetadata = {};
+  const repoName = getRepoName(cwd);
+  if (repoName != null) {
+    repoMetadata.repository_name = repoName.name;
+    repoMetadata.repository_provider = repoName.provider;
+  }
+  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,

--- a/bundle/stop-failure.js
+++ b/bundle/stop-failure.js
@@ -840,7 +840,7 @@ function v7(options, buf, offset) {
 }
 var v7_default = v7;
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/constants.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/constants.js
 var GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 var GEN_AI_SYSTEM = "gen_ai.system";
 var GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -875,7 +875,7 @@ var LANGSMITH_TAGS = "langsmith.span.tags";
 var LANGSMITH_REQUEST_STREAMING = "langsmith.request.streaming";
 var LANGSMITH_REQUEST_HEADERS = "langsmith.request.headers";
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/env.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/env.js
 var globalEnv;
 var isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";
 var isWebWorker = () => typeof globalThis === "object" && globalThis.constructor && globalThis.constructor.name === "DedicatedWorkerGlobalScope";
@@ -1015,7 +1015,7 @@ function getOtelEnabled() {
   return getEnvironmentVariable("OTEL_ENABLED") === "true" || getLangSmithEnvironmentVariable("OTEL_ENABLED") === "true";
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/otel.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/otel.js
 var MockTracer = class {
   constructor() {
     Object.defineProperty(this, "hasWarned", {
@@ -1121,7 +1121,7 @@ function getDefaultOTLPTracerComponents() {
   return OTELProviderSingleton.getDefaultOTLPTracerComponents();
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/translator.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/translator.js
 var WELL_KNOWN_OPERATION_NAMES = {
   llm: "chat",
   tool: "execute_tool",
@@ -1462,7 +1462,7 @@ var LangSmithToOTELTranslator = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/is-network-error/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/is-network-error/index.js
 var objectToString = Object.prototype.toString;
 var isError = (value) => objectToString.call(value) === "[object Error]";
 var errorMessages = /* @__PURE__ */ new Set([
@@ -1501,7 +1501,7 @@ function isNetworkError(error2) {
   return errorMessages.has(message);
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-retry/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-retry/index.js
 function validateRetries(retries) {
   if (typeof retries === "number") {
     if (retries < 0) {
@@ -1674,11 +1674,11 @@ async function pRetry(input, options = {}) {
   throw new Error("Retry attempts exhausted without throwing an error.");
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-queue.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-queue.js
 var import_p_queue = __toESM(require_dist(), 1);
 var PQueue = "default" in import_p_queue.default ? import_p_queue.default.default : import_p_queue.default;
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/async_caller.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/async_caller.js
 var STATUS_RETRYABLE = [
   408,
   // Request Timeout
@@ -1806,7 +1806,7 @@ var AsyncCaller = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/messages.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/messages.js
 function isLangChainMessage(message) {
   return typeof message?._getType === "function";
 }
@@ -1821,7 +1821,7 @@ function convertLangChainMessageToExample(message) {
   return converted;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/warn.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/warn.js
 var warnedMessages = {};
 function warnOnce(message) {
   if (!warnedMessages[message]) {
@@ -1830,7 +1830,7 @@ function warnOnce(message) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/xxhash/xxhash.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/xxhash/xxhash.js
 var n = (n2) => BigInt(n2);
 var PRIME32_1 = n("0x9E3779B1");
 var PRIME32_2 = n("0x85EBCA77");
@@ -2110,7 +2110,7 @@ function xxh128ToBytes(hash128) {
   return result;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/_uuid.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/_uuid.js
 var UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function assertUuid(str, which) {
   if (!UUID_REGEX.test(str)) {
@@ -2172,7 +2172,7 @@ function nonCryptographicUuid7Deterministic(originalId, key) {
   return bytesToUuid(b);
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/error.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/error.js
 function getInvalidPromptIdentifierMsg(identifier) {
   return `Invalid prompt identifier format: "${identifier}". Expected one of:
   - "prompt-name" (for private prompts)
@@ -2265,7 +2265,7 @@ function isConflictingEndpointsError(err) {
   return typeof err === "object" && err !== null && err.code === ERR_CONFLICTING_ENDPOINTS;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompts.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompts.js
 function parsePromptIdentifier(identifier) {
   if (!identifier || identifier.split("/").length > 2 || identifier.startsWith("/") || identifier.endsWith("/") || identifier.split(":").length > 2) {
     throw new Error(getInvalidPromptIdentifierMsg(identifier));
@@ -2286,7 +2286,7 @@ function parsePromptIdentifier(identifier) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fs.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fs.js
 import * as nodeFs from "node:fs";
 import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
@@ -2327,7 +2327,7 @@ function readFileSync2(filePath) {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompt_cache/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompt_cache/index.js
 function isStale(entry, ttlSeconds) {
   if (ttlSeconds === null) {
     return false;
@@ -2601,7 +2601,7 @@ var PromptCache = class {
 };
 var promptCacheSingleton = new PromptCache();
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/fetch.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/fetch.js
 var DEFAULT_FETCH_IMPLEMENTATION = (...args) => fetch(...args);
 var globalFetchSupportsWebStreaming = void 0;
 var LANGSMITH_FETCH_IMPLEMENTATION_KEY = /* @__PURE__ */ Symbol.for("ls:fetch_implementation");
@@ -2626,7 +2626,7 @@ var _getFetchImplementation = (debug2) => {
   };
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
 var LIMIT_REPLACE_NODE = "[...]";
 var CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
 var arr = [];
@@ -2778,7 +2778,7 @@ function replaceGetterValues(replacer) {
   };
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/client.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/client.js
 function _ensureUTCTimestamp(ts) {
   if (typeof ts === "string" && ts.length > 0 && !ts.includes("Z") && !ts.includes("+") && !ts.includes("-", 10)) {
     return ts + "Z";
@@ -3342,6 +3342,22 @@ var Client = class _Client {
     }
     return outputs;
   }
+  /**
+   * Filter content from new_token events to prevent streaming LLM output
+   * from being uploaded via events.
+   */
+  _filterNewTokenEvents(events) {
+    if (!events || events.length === 0) {
+      return events;
+    }
+    return events.map((event) => {
+      if (event.name === "new_token") {
+        const { kwargs: _, ...rest } = event;
+        return rest;
+      }
+      return event;
+    });
+  }
   async prepareRunCreateOrUpdateInputs(run) {
     const runParams = { ...run };
     if (runParams.inputs !== void 0) {
@@ -3349,6 +3365,9 @@ var Client = class _Client {
     }
     if (runParams.outputs !== void 0) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
+    }
+    if (runParams.events !== void 0) {
+      runParams.events = this._filterNewTokenEvents(runParams.events);
     }
     return runParams;
   }
@@ -4109,6 +4128,9 @@ Context: ${context}`);
     }
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
+    }
+    if (run.events) {
+      run.events = this._filterNewTokenEvents(run.events);
     }
     const data = { ...run, id: runId };
     if (!this._filterForSampling([data], true).length) {
@@ -6970,7 +6992,7 @@ function isExampleCreate(input) {
   return "dataset_id" in input || "dataset_name" in input;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/env.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/env.js
 var isTracingEnabled = (tracingEnabled) => {
   if (tracingEnabled !== void 0) {
     return tracingEnabled;
@@ -6979,11 +7001,11 @@ var isTracingEnabled = (tracingEnabled) => {
   return !!envVars.find((envVar) => getLangSmithEnvironmentVariable(envVar) === "true");
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/constants.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/constants.js
 var _LC_CONTEXT_VARIABLES_KEY = /* @__PURE__ */ Symbol.for("lc:context_variables");
 var _REPLICA_TRACE_ROOTS_KEY = /* @__PURE__ */ Symbol.for("langsmith:replica_trace_roots");
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/context_vars.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/context_vars.js
 function getContextVar(runTree, key) {
   if (_LC_CONTEXT_VARIABLES_KEY in runTree) {
     const contextVars = runTree[_LC_CONTEXT_VARIABLES_KEY];
@@ -7000,13 +7022,13 @@ function setContextVar(runTree, key, value) {
   runTree[_LC_CONTEXT_VARIABLES_KEY] = contextVars;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/project.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/project.js
 var getDefaultProjectName = () => {
   return getLangSmithEnvironmentVariable("PROJECT") ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? // TODO: Deprecate
   "default";
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/run_trees.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/run_trees.js
 var TIMESTAMP_LENGTH = 36;
 var UUID_NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 function getReplicaKey(replica) {
@@ -7907,8 +7929,8 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/index.js
-var __version__ = "0.5.18";
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/index.js
+var __version__ = "0.5.19";
 
 // dist/transcript.js
 import { readFileSync as readFileSync3, statSync as statSync2, openSync, readSync, closeSync } from "node:fs";

--- a/bundle/stop-failure.js
+++ b/bundle/stop-failure.js
@@ -840,7 +840,7 @@ function v7(options, buf, offset) {
 }
 var v7_default = v7;
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/constants.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/constants.js
 var GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 var GEN_AI_SYSTEM = "gen_ai.system";
 var GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -875,7 +875,7 @@ var LANGSMITH_TAGS = "langsmith.span.tags";
 var LANGSMITH_REQUEST_STREAMING = "langsmith.request.streaming";
 var LANGSMITH_REQUEST_HEADERS = "langsmith.request.headers";
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/env.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/env.js
 var globalEnv;
 var isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";
 var isWebWorker = () => typeof globalThis === "object" && globalThis.constructor && globalThis.constructor.name === "DedicatedWorkerGlobalScope";
@@ -1015,7 +1015,7 @@ function getOtelEnabled() {
   return getEnvironmentVariable("OTEL_ENABLED") === "true" || getLangSmithEnvironmentVariable("OTEL_ENABLED") === "true";
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/otel.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/otel.js
 var MockTracer = class {
   constructor() {
     Object.defineProperty(this, "hasWarned", {
@@ -1121,7 +1121,7 @@ function getDefaultOTLPTracerComponents() {
   return OTELProviderSingleton.getDefaultOTLPTracerComponents();
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/translator.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/translator.js
 var WELL_KNOWN_OPERATION_NAMES = {
   llm: "chat",
   tool: "execute_tool",
@@ -1462,7 +1462,7 @@ var LangSmithToOTELTranslator = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/is-network-error/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/is-network-error/index.js
 var objectToString = Object.prototype.toString;
 var isError = (value) => objectToString.call(value) === "[object Error]";
 var errorMessages = /* @__PURE__ */ new Set([
@@ -1501,7 +1501,7 @@ function isNetworkError(error2) {
   return errorMessages.has(message);
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-retry/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-retry/index.js
 function validateRetries(retries) {
   if (typeof retries === "number") {
     if (retries < 0) {
@@ -1674,11 +1674,11 @@ async function pRetry(input, options = {}) {
   throw new Error("Retry attempts exhausted without throwing an error.");
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-queue.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-queue.js
 var import_p_queue = __toESM(require_dist(), 1);
 var PQueue = "default" in import_p_queue.default ? import_p_queue.default.default : import_p_queue.default;
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/async_caller.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/async_caller.js
 var STATUS_RETRYABLE = [
   408,
   // Request Timeout
@@ -1806,7 +1806,7 @@ var AsyncCaller = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/messages.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/messages.js
 function isLangChainMessage(message) {
   return typeof message?._getType === "function";
 }
@@ -1821,7 +1821,7 @@ function convertLangChainMessageToExample(message) {
   return converted;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/warn.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/warn.js
 var warnedMessages = {};
 function warnOnce(message) {
   if (!warnedMessages[message]) {
@@ -1830,7 +1830,7 @@ function warnOnce(message) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/xxhash/xxhash.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/xxhash/xxhash.js
 var n = (n2) => BigInt(n2);
 var PRIME32_1 = n("0x9E3779B1");
 var PRIME32_2 = n("0x85EBCA77");
@@ -2110,7 +2110,7 @@ function xxh128ToBytes(hash128) {
   return result;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/_uuid.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/_uuid.js
 var UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function assertUuid(str, which) {
   if (!UUID_REGEX.test(str)) {
@@ -2172,7 +2172,7 @@ function nonCryptographicUuid7Deterministic(originalId, key) {
   return bytesToUuid(b);
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/error.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/error.js
 function getInvalidPromptIdentifierMsg(identifier) {
   return `Invalid prompt identifier format: "${identifier}". Expected one of:
   - "prompt-name" (for private prompts)
@@ -2265,7 +2265,7 @@ function isConflictingEndpointsError(err) {
   return typeof err === "object" && err !== null && err.code === ERR_CONFLICTING_ENDPOINTS;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompts.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompts.js
 function parsePromptIdentifier(identifier) {
   if (!identifier || identifier.split("/").length > 2 || identifier.startsWith("/") || identifier.endsWith("/") || identifier.split(":").length > 2) {
     throw new Error(getInvalidPromptIdentifierMsg(identifier));
@@ -2286,7 +2286,7 @@ function parsePromptIdentifier(identifier) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fs.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fs.js
 import * as nodeFs from "node:fs";
 import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
@@ -2327,7 +2327,7 @@ function readFileSync2(filePath) {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompt_cache/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompt_cache/index.js
 function isStale(entry, ttlSeconds) {
   if (ttlSeconds === null) {
     return false;
@@ -2601,7 +2601,7 @@ var PromptCache = class {
 };
 var promptCacheSingleton = new PromptCache();
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/fetch.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/fetch.js
 var DEFAULT_FETCH_IMPLEMENTATION = (...args) => fetch(...args);
 var globalFetchSupportsWebStreaming = void 0;
 var LANGSMITH_FETCH_IMPLEMENTATION_KEY = /* @__PURE__ */ Symbol.for("ls:fetch_implementation");
@@ -2626,7 +2626,7 @@ var _getFetchImplementation = (debug2) => {
   };
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
 var LIMIT_REPLACE_NODE = "[...]";
 var CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
 var arr = [];
@@ -2778,7 +2778,7 @@ function replaceGetterValues(replacer) {
   };
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/client.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/client.js
 function _ensureUTCTimestamp(ts) {
   if (typeof ts === "string" && ts.length > 0 && !ts.includes("Z") && !ts.includes("+") && !ts.includes("-", 10)) {
     return ts + "Z";
@@ -3342,22 +3342,6 @@ var Client = class _Client {
     }
     return outputs;
   }
-  /**
-   * Filter content from new_token events to prevent streaming LLM output
-   * from being uploaded via events.
-   */
-  _filterNewTokenEvents(events) {
-    if (!events || events.length === 0) {
-      return events;
-    }
-    return events.map((event) => {
-      if (event.name === "new_token") {
-        const { kwargs: _, ...rest } = event;
-        return rest;
-      }
-      return event;
-    });
-  }
   async prepareRunCreateOrUpdateInputs(run) {
     const runParams = { ...run };
     if (runParams.inputs !== void 0) {
@@ -3365,9 +3349,6 @@ var Client = class _Client {
     }
     if (runParams.outputs !== void 0) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
-    }
-    if (runParams.events !== void 0) {
-      runParams.events = this._filterNewTokenEvents(runParams.events);
     }
     return runParams;
   }
@@ -4128,9 +4109,6 @@ Context: ${context}`);
     }
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
-    }
-    if (run.events) {
-      run.events = this._filterNewTokenEvents(run.events);
     }
     const data = { ...run, id: runId };
     if (!this._filterForSampling([data], true).length) {
@@ -6992,7 +6970,7 @@ function isExampleCreate(input) {
   return "dataset_id" in input || "dataset_name" in input;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/env.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/env.js
 var isTracingEnabled = (tracingEnabled) => {
   if (tracingEnabled !== void 0) {
     return tracingEnabled;
@@ -7001,11 +6979,11 @@ var isTracingEnabled = (tracingEnabled) => {
   return !!envVars.find((envVar) => getLangSmithEnvironmentVariable(envVar) === "true");
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/constants.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/constants.js
 var _LC_CONTEXT_VARIABLES_KEY = /* @__PURE__ */ Symbol.for("lc:context_variables");
 var _REPLICA_TRACE_ROOTS_KEY = /* @__PURE__ */ Symbol.for("langsmith:replica_trace_roots");
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/context_vars.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/context_vars.js
 function getContextVar(runTree, key) {
   if (_LC_CONTEXT_VARIABLES_KEY in runTree) {
     const contextVars = runTree[_LC_CONTEXT_VARIABLES_KEY];
@@ -7022,13 +7000,13 @@ function setContextVar(runTree, key, value) {
   runTree[_LC_CONTEXT_VARIABLES_KEY] = contextVars;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/project.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/project.js
 var getDefaultProjectName = () => {
   return getLangSmithEnvironmentVariable("PROJECT") ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? // TODO: Deprecate
   "default";
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/run_trees.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/run_trees.js
 var TIMESTAMP_LENGTH = 36;
 var UUID_NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 function getReplicaKey(replica) {
@@ -7929,8 +7907,8 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/index.js
-var __version__ = "0.5.19";
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/index.js
+var __version__ = "0.5.18";
 
 // dist/transcript.js
 import { readFileSync as readFileSync3, statSync as statSync2, openSync, readSync, closeSync } from "node:fs";
@@ -8026,6 +8004,7 @@ async function flushPendingTraces() {
 import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -8046,7 +8025,48 @@ function readAnthropicUserId() {
 function readLocalUsername() {
   return userInfo().username;
 }
-function loadConfig() {
+var GIT_PROVIDERS_REGEX = {
+  github: /[@/](?:github\.com)[:/](.+?)(?:\.git)?\s/,
+  gitlab: /[@/](?:gitlab\.com)[:/](.+?)(?:\.git)?\s/,
+  bitbucket: /[@/](?:bitbucket\.org)[:/](.+?)(?:\.git)?\s/,
+  devAzure: /[@/](?:dev\.azure\.com)[:/](.+?)(?:\.git)?\s/
+};
+function parseRepoName(remoteUrl) {
+  for (const [provider, regex] of Object.entries(GIT_PROVIDERS_REGEX)) {
+    const match = remoteUrl.match(regex);
+    if (match)
+      return { provider, name: match[1] };
+  }
+  return void 0;
+}
+function getRepoName(cwd) {
+  try {
+    const output = execSync("git remote -v", { cwd, encoding: "utf-8", timeout: 5e3 });
+    const lines = output.trim().split("\n").filter(Boolean);
+    const remotes = [];
+    for (const line of lines) {
+      const parts = line.split(/\s+/);
+      if (parts.length >= 2 && line.includes("(fetch)")) {
+        remotes.push({ name: parts[0], url: parts[1] });
+      }
+    }
+    const origin = remotes.find((r) => r.name === "origin");
+    if (origin) {
+      const name = parseRepoName(origin.url + " ");
+      if (name)
+        return name;
+    }
+    for (const remote of remotes) {
+      const name = parseRepoName(remote.url + " ");
+      if (name)
+        return name;
+    }
+  } catch {
+  }
+  return void 0;
+}
+function loadConfig(options) {
+  const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
   const project = process.env.CC_LANGSMITH_PROJECT ?? "claude-code";
   const apiBaseUrl = process.env.LANGSMITH_ENDPOINT ?? "https://api.smith.langchain.com";
@@ -8083,7 +8103,13 @@ function loadConfig() {
   if (anthropicUserId) {
     identityMetadata.anthropic_user_id = anthropicUserId;
   }
-  customMetadata = { ...identityMetadata, ...customMetadata };
+  const repoMetadata = {};
+  const repoName = getRepoName(cwd);
+  if (repoName != null) {
+    repoMetadata.repository_name = repoName.name;
+    repoMetadata.repository_provider = repoName.provider;
+  }
+  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -1158,7 +1158,7 @@ function v7(options, buf, offset) {
 }
 var v7_default = v7;
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/constants.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/constants.js
 var GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 var GEN_AI_SYSTEM = "gen_ai.system";
 var GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -1193,7 +1193,7 @@ var LANGSMITH_TAGS = "langsmith.span.tags";
 var LANGSMITH_REQUEST_STREAMING = "langsmith.request.streaming";
 var LANGSMITH_REQUEST_HEADERS = "langsmith.request.headers";
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/env.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/env.js
 var globalEnv;
 var isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";
 var isWebWorker = () => typeof globalThis === "object" && globalThis.constructor && globalThis.constructor.name === "DedicatedWorkerGlobalScope";
@@ -1333,7 +1333,7 @@ function getOtelEnabled() {
   return getEnvironmentVariable("OTEL_ENABLED") === "true" || getLangSmithEnvironmentVariable("OTEL_ENABLED") === "true";
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/otel.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/otel.js
 var MockTracer = class {
   constructor() {
     Object.defineProperty(this, "hasWarned", {
@@ -1439,7 +1439,7 @@ function getDefaultOTLPTracerComponents() {
   return OTELProviderSingleton.getDefaultOTLPTracerComponents();
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/translator.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/translator.js
 var WELL_KNOWN_OPERATION_NAMES = {
   llm: "chat",
   tool: "execute_tool",
@@ -1780,7 +1780,7 @@ var LangSmithToOTELTranslator = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/is-network-error/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/is-network-error/index.js
 var objectToString = Object.prototype.toString;
 var isError = (value) => objectToString.call(value) === "[object Error]";
 var errorMessages = /* @__PURE__ */ new Set([
@@ -1819,7 +1819,7 @@ function isNetworkError(error2) {
   return errorMessages.has(message);
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-retry/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-retry/index.js
 function validateRetries(retries) {
   if (typeof retries === "number") {
     if (retries < 0) {
@@ -1992,11 +1992,11 @@ async function pRetry(input, options = {}) {
   throw new Error("Retry attempts exhausted without throwing an error.");
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-queue.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-queue.js
 var import_p_queue = __toESM(require_dist(), 1);
 var PQueue = "default" in import_p_queue.default ? import_p_queue.default.default : import_p_queue.default;
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/async_caller.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/async_caller.js
 var STATUS_RETRYABLE = [
   408,
   // Request Timeout
@@ -2124,7 +2124,7 @@ var AsyncCaller = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/messages.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/messages.js
 function isLangChainMessage(message) {
   return typeof message?._getType === "function";
 }
@@ -2139,7 +2139,7 @@ function convertLangChainMessageToExample(message) {
   return converted;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/warn.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/warn.js
 var warnedMessages = {};
 function warnOnce(message) {
   if (!warnedMessages[message]) {
@@ -2148,7 +2148,7 @@ function warnOnce(message) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/xxhash/xxhash.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/xxhash/xxhash.js
 var n = (n2) => BigInt(n2);
 var PRIME32_1 = n("0x9E3779B1");
 var PRIME32_2 = n("0x85EBCA77");
@@ -2428,7 +2428,7 @@ function xxh128ToBytes(hash128) {
   return result;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/_uuid.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/_uuid.js
 var UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function assertUuid(str, which) {
   if (!UUID_REGEX.test(str)) {
@@ -2490,7 +2490,7 @@ function nonCryptographicUuid7Deterministic(originalId, key) {
   return bytesToUuid(b);
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/error.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/error.js
 function getInvalidPromptIdentifierMsg(identifier) {
   return `Invalid prompt identifier format: "${identifier}". Expected one of:
   - "prompt-name" (for private prompts)
@@ -2583,7 +2583,7 @@ function isConflictingEndpointsError(err) {
   return typeof err === "object" && err !== null && err.code === ERR_CONFLICTING_ENDPOINTS;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompts.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompts.js
 function parsePromptIdentifier(identifier) {
   if (!identifier || identifier.split("/").length > 2 || identifier.startsWith("/") || identifier.endsWith("/") || identifier.split(":").length > 2) {
     throw new Error(getInvalidPromptIdentifierMsg(identifier));
@@ -2604,7 +2604,7 @@ function parsePromptIdentifier(identifier) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fs.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fs.js
 import * as nodeFs from "node:fs";
 import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
@@ -2645,7 +2645,7 @@ function readFileSync4(filePath) {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompt_cache/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompt_cache/index.js
 function isStale(entry, ttlSeconds) {
   if (ttlSeconds === null) {
     return false;
@@ -2919,7 +2919,7 @@ var PromptCache = class {
 };
 var promptCacheSingleton = new PromptCache();
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/fetch.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/fetch.js
 var DEFAULT_FETCH_IMPLEMENTATION = (...args) => fetch(...args);
 var globalFetchSupportsWebStreaming = void 0;
 var LANGSMITH_FETCH_IMPLEMENTATION_KEY = /* @__PURE__ */ Symbol.for("ls:fetch_implementation");
@@ -2944,7 +2944,7 @@ var _getFetchImplementation = (debug2) => {
   };
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
 var LIMIT_REPLACE_NODE = "[...]";
 var CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
 var arr = [];
@@ -3096,7 +3096,7 @@ function replaceGetterValues(replacer) {
   };
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/client.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/client.js
 function _ensureUTCTimestamp(ts) {
   if (typeof ts === "string" && ts.length > 0 && !ts.includes("Z") && !ts.includes("+") && !ts.includes("-", 10)) {
     return ts + "Z";
@@ -3660,6 +3660,22 @@ var Client = class _Client {
     }
     return outputs;
   }
+  /**
+   * Filter content from new_token events to prevent streaming LLM output
+   * from being uploaded via events.
+   */
+  _filterNewTokenEvents(events) {
+    if (!events || events.length === 0) {
+      return events;
+    }
+    return events.map((event) => {
+      if (event.name === "new_token") {
+        const { kwargs: _, ...rest } = event;
+        return rest;
+      }
+      return event;
+    });
+  }
   async prepareRunCreateOrUpdateInputs(run) {
     const runParams = { ...run };
     if (runParams.inputs !== void 0) {
@@ -3667,6 +3683,9 @@ var Client = class _Client {
     }
     if (runParams.outputs !== void 0) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
+    }
+    if (runParams.events !== void 0) {
+      runParams.events = this._filterNewTokenEvents(runParams.events);
     }
     return runParams;
   }
@@ -4427,6 +4446,9 @@ Context: ${context}`);
     }
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
+    }
+    if (run.events) {
+      run.events = this._filterNewTokenEvents(run.events);
     }
     const data = { ...run, id: runId };
     if (!this._filterForSampling([data], true).length) {
@@ -7288,7 +7310,7 @@ function isExampleCreate(input) {
   return "dataset_id" in input || "dataset_name" in input;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/env.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/env.js
 var isTracingEnabled = (tracingEnabled) => {
   if (tracingEnabled !== void 0) {
     return tracingEnabled;
@@ -7297,11 +7319,11 @@ var isTracingEnabled = (tracingEnabled) => {
   return !!envVars.find((envVar) => getLangSmithEnvironmentVariable(envVar) === "true");
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/constants.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/constants.js
 var _LC_CONTEXT_VARIABLES_KEY = /* @__PURE__ */ Symbol.for("lc:context_variables");
 var _REPLICA_TRACE_ROOTS_KEY = /* @__PURE__ */ Symbol.for("langsmith:replica_trace_roots");
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/context_vars.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/context_vars.js
 function getContextVar(runTree, key) {
   if (_LC_CONTEXT_VARIABLES_KEY in runTree) {
     const contextVars = runTree[_LC_CONTEXT_VARIABLES_KEY];
@@ -7318,13 +7340,13 @@ function setContextVar(runTree, key, value) {
   runTree[_LC_CONTEXT_VARIABLES_KEY] = contextVars;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/project.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/project.js
 var getDefaultProjectName = () => {
   return getLangSmithEnvironmentVariable("PROJECT") ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? // TODO: Deprecate
   "default";
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/run_trees.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/run_trees.js
 var TIMESTAMP_LENGTH = 36;
 var UUID_NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 function getReplicaKey(replica) {
@@ -8225,13 +8247,13 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/uuid.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/uuid.js
 function uuid7() {
   return v7_default();
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/index.js
-var __version__ = "0.5.18";
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/index.js
+var __version__ = "0.5.19";
 
 // dist/constants.js
 var USER_PROMPT_TURN_NAME = "Claude Code Turn";

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -1158,7 +1158,7 @@ function v7(options, buf, offset) {
 }
 var v7_default = v7;
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/constants.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/constants.js
 var GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 var GEN_AI_SYSTEM = "gen_ai.system";
 var GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -1193,7 +1193,7 @@ var LANGSMITH_TAGS = "langsmith.span.tags";
 var LANGSMITH_REQUEST_STREAMING = "langsmith.request.streaming";
 var LANGSMITH_REQUEST_HEADERS = "langsmith.request.headers";
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/env.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/env.js
 var globalEnv;
 var isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";
 var isWebWorker = () => typeof globalThis === "object" && globalThis.constructor && globalThis.constructor.name === "DedicatedWorkerGlobalScope";
@@ -1333,7 +1333,7 @@ function getOtelEnabled() {
   return getEnvironmentVariable("OTEL_ENABLED") === "true" || getLangSmithEnvironmentVariable("OTEL_ENABLED") === "true";
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/otel.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/otel.js
 var MockTracer = class {
   constructor() {
     Object.defineProperty(this, "hasWarned", {
@@ -1439,7 +1439,7 @@ function getDefaultOTLPTracerComponents() {
   return OTELProviderSingleton.getDefaultOTLPTracerComponents();
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/translator.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/translator.js
 var WELL_KNOWN_OPERATION_NAMES = {
   llm: "chat",
   tool: "execute_tool",
@@ -1780,7 +1780,7 @@ var LangSmithToOTELTranslator = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/is-network-error/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/is-network-error/index.js
 var objectToString = Object.prototype.toString;
 var isError = (value) => objectToString.call(value) === "[object Error]";
 var errorMessages = /* @__PURE__ */ new Set([
@@ -1819,7 +1819,7 @@ function isNetworkError(error2) {
   return errorMessages.has(message);
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-retry/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-retry/index.js
 function validateRetries(retries) {
   if (typeof retries === "number") {
     if (retries < 0) {
@@ -1992,11 +1992,11 @@ async function pRetry(input, options = {}) {
   throw new Error("Retry attempts exhausted without throwing an error.");
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-queue.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-queue.js
 var import_p_queue = __toESM(require_dist(), 1);
 var PQueue = "default" in import_p_queue.default ? import_p_queue.default.default : import_p_queue.default;
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/async_caller.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/async_caller.js
 var STATUS_RETRYABLE = [
   408,
   // Request Timeout
@@ -2124,7 +2124,7 @@ var AsyncCaller = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/messages.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/messages.js
 function isLangChainMessage(message) {
   return typeof message?._getType === "function";
 }
@@ -2139,7 +2139,7 @@ function convertLangChainMessageToExample(message) {
   return converted;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/warn.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/warn.js
 var warnedMessages = {};
 function warnOnce(message) {
   if (!warnedMessages[message]) {
@@ -2148,7 +2148,7 @@ function warnOnce(message) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/xxhash/xxhash.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/xxhash/xxhash.js
 var n = (n2) => BigInt(n2);
 var PRIME32_1 = n("0x9E3779B1");
 var PRIME32_2 = n("0x85EBCA77");
@@ -2428,7 +2428,7 @@ function xxh128ToBytes(hash128) {
   return result;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/_uuid.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/_uuid.js
 var UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function assertUuid(str, which) {
   if (!UUID_REGEX.test(str)) {
@@ -2490,7 +2490,7 @@ function nonCryptographicUuid7Deterministic(originalId, key) {
   return bytesToUuid(b);
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/error.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/error.js
 function getInvalidPromptIdentifierMsg(identifier) {
   return `Invalid prompt identifier format: "${identifier}". Expected one of:
   - "prompt-name" (for private prompts)
@@ -2583,7 +2583,7 @@ function isConflictingEndpointsError(err) {
   return typeof err === "object" && err !== null && err.code === ERR_CONFLICTING_ENDPOINTS;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompts.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompts.js
 function parsePromptIdentifier(identifier) {
   if (!identifier || identifier.split("/").length > 2 || identifier.startsWith("/") || identifier.endsWith("/") || identifier.split(":").length > 2) {
     throw new Error(getInvalidPromptIdentifierMsg(identifier));
@@ -2604,7 +2604,7 @@ function parsePromptIdentifier(identifier) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fs.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fs.js
 import * as nodeFs from "node:fs";
 import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
@@ -2645,7 +2645,7 @@ function readFileSync4(filePath) {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompt_cache/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompt_cache/index.js
 function isStale(entry, ttlSeconds) {
   if (ttlSeconds === null) {
     return false;
@@ -2919,7 +2919,7 @@ var PromptCache = class {
 };
 var promptCacheSingleton = new PromptCache();
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/fetch.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/fetch.js
 var DEFAULT_FETCH_IMPLEMENTATION = (...args) => fetch(...args);
 var globalFetchSupportsWebStreaming = void 0;
 var LANGSMITH_FETCH_IMPLEMENTATION_KEY = /* @__PURE__ */ Symbol.for("ls:fetch_implementation");
@@ -2944,7 +2944,7 @@ var _getFetchImplementation = (debug2) => {
   };
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
 var LIMIT_REPLACE_NODE = "[...]";
 var CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
 var arr = [];
@@ -3096,7 +3096,7 @@ function replaceGetterValues(replacer) {
   };
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/client.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/client.js
 function _ensureUTCTimestamp(ts) {
   if (typeof ts === "string" && ts.length > 0 && !ts.includes("Z") && !ts.includes("+") && !ts.includes("-", 10)) {
     return ts + "Z";
@@ -3660,22 +3660,6 @@ var Client = class _Client {
     }
     return outputs;
   }
-  /**
-   * Filter content from new_token events to prevent streaming LLM output
-   * from being uploaded via events.
-   */
-  _filterNewTokenEvents(events) {
-    if (!events || events.length === 0) {
-      return events;
-    }
-    return events.map((event) => {
-      if (event.name === "new_token") {
-        const { kwargs: _, ...rest } = event;
-        return rest;
-      }
-      return event;
-    });
-  }
   async prepareRunCreateOrUpdateInputs(run) {
     const runParams = { ...run };
     if (runParams.inputs !== void 0) {
@@ -3683,9 +3667,6 @@ var Client = class _Client {
     }
     if (runParams.outputs !== void 0) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
-    }
-    if (runParams.events !== void 0) {
-      runParams.events = this._filterNewTokenEvents(runParams.events);
     }
     return runParams;
   }
@@ -4446,9 +4427,6 @@ Context: ${context}`);
     }
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
-    }
-    if (run.events) {
-      run.events = this._filterNewTokenEvents(run.events);
     }
     const data = { ...run, id: runId };
     if (!this._filterForSampling([data], true).length) {
@@ -7310,7 +7288,7 @@ function isExampleCreate(input) {
   return "dataset_id" in input || "dataset_name" in input;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/env.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/env.js
 var isTracingEnabled = (tracingEnabled) => {
   if (tracingEnabled !== void 0) {
     return tracingEnabled;
@@ -7319,11 +7297,11 @@ var isTracingEnabled = (tracingEnabled) => {
   return !!envVars.find((envVar) => getLangSmithEnvironmentVariable(envVar) === "true");
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/constants.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/constants.js
 var _LC_CONTEXT_VARIABLES_KEY = /* @__PURE__ */ Symbol.for("lc:context_variables");
 var _REPLICA_TRACE_ROOTS_KEY = /* @__PURE__ */ Symbol.for("langsmith:replica_trace_roots");
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/context_vars.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/context_vars.js
 function getContextVar(runTree, key) {
   if (_LC_CONTEXT_VARIABLES_KEY in runTree) {
     const contextVars = runTree[_LC_CONTEXT_VARIABLES_KEY];
@@ -7340,13 +7318,13 @@ function setContextVar(runTree, key, value) {
   runTree[_LC_CONTEXT_VARIABLES_KEY] = contextVars;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/project.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/project.js
 var getDefaultProjectName = () => {
   return getLangSmithEnvironmentVariable("PROJECT") ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? // TODO: Deprecate
   "default";
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/run_trees.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/run_trees.js
 var TIMESTAMP_LENGTH = 36;
 var UUID_NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 function getReplicaKey(replica) {
@@ -8247,13 +8225,13 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/uuid.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/uuid.js
 function uuid7() {
   return v7_default();
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/index.js
-var __version__ = "0.5.19";
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/index.js
+var __version__ = "0.5.18";
 
 // dist/constants.js
 var USER_PROMPT_TURN_NAME = "Claude Code Turn";
@@ -8604,6 +8582,7 @@ async function tracePendingSubagents(options) {
 import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -8624,7 +8603,48 @@ function readAnthropicUserId() {
 function readLocalUsername() {
   return userInfo().username;
 }
-function loadConfig() {
+var GIT_PROVIDERS_REGEX = {
+  github: /[@/](?:github\.com)[:/](.+?)(?:\.git)?\s/,
+  gitlab: /[@/](?:gitlab\.com)[:/](.+?)(?:\.git)?\s/,
+  bitbucket: /[@/](?:bitbucket\.org)[:/](.+?)(?:\.git)?\s/,
+  devAzure: /[@/](?:dev\.azure\.com)[:/](.+?)(?:\.git)?\s/
+};
+function parseRepoName(remoteUrl) {
+  for (const [provider, regex] of Object.entries(GIT_PROVIDERS_REGEX)) {
+    const match = remoteUrl.match(regex);
+    if (match)
+      return { provider, name: match[1] };
+  }
+  return void 0;
+}
+function getRepoName(cwd) {
+  try {
+    const output = execSync("git remote -v", { cwd, encoding: "utf-8", timeout: 5e3 });
+    const lines = output.trim().split("\n").filter(Boolean);
+    const remotes = [];
+    for (const line of lines) {
+      const parts = line.split(/\s+/);
+      if (parts.length >= 2 && line.includes("(fetch)")) {
+        remotes.push({ name: parts[0], url: parts[1] });
+      }
+    }
+    const origin = remotes.find((r) => r.name === "origin");
+    if (origin) {
+      const name = parseRepoName(origin.url + " ");
+      if (name)
+        return name;
+    }
+    for (const remote of remotes) {
+      const name = parseRepoName(remote.url + " ");
+      if (name)
+        return name;
+    }
+  } catch {
+  }
+  return void 0;
+}
+function loadConfig(options) {
+  const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
   const project = process.env.CC_LANGSMITH_PROJECT ?? "claude-code";
   const apiBaseUrl = process.env.LANGSMITH_ENDPOINT ?? "https://api.smith.langchain.com";
@@ -8661,7 +8681,13 @@ function loadConfig() {
   if (anthropicUserId) {
     identityMetadata.anthropic_user_id = anthropicUserId;
   }
-  customMetadata = { ...identityMetadata, ...customMetadata };
+  const repoMetadata = {};
+  const repoName = getRepoName(cwd);
+  if (repoName != null) {
+    repoMetadata.repository_name = repoName.name;
+    repoMetadata.repository_provider = repoName.provider;
+  }
+  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,

--- a/bundle/subagent-stop.js
+++ b/bundle/subagent-stop.js
@@ -103,6 +103,7 @@ var SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 import { readFileSync as readFileSync2 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -123,7 +124,48 @@ function readAnthropicUserId() {
 function readLocalUsername() {
   return userInfo().username;
 }
-function loadConfig() {
+var GIT_PROVIDERS_REGEX = {
+  github: /[@/](?:github\.com)[:/](.+?)(?:\.git)?\s/,
+  gitlab: /[@/](?:gitlab\.com)[:/](.+?)(?:\.git)?\s/,
+  bitbucket: /[@/](?:bitbucket\.org)[:/](.+?)(?:\.git)?\s/,
+  devAzure: /[@/](?:dev\.azure\.com)[:/](.+?)(?:\.git)?\s/
+};
+function parseRepoName(remoteUrl) {
+  for (const [provider, regex] of Object.entries(GIT_PROVIDERS_REGEX)) {
+    const match = remoteUrl.match(regex);
+    if (match)
+      return { provider, name: match[1] };
+  }
+  return void 0;
+}
+function getRepoName(cwd) {
+  try {
+    const output = execSync("git remote -v", { cwd, encoding: "utf-8", timeout: 5e3 });
+    const lines = output.trim().split("\n").filter(Boolean);
+    const remotes = [];
+    for (const line of lines) {
+      const parts = line.split(/\s+/);
+      if (parts.length >= 2 && line.includes("(fetch)")) {
+        remotes.push({ name: parts[0], url: parts[1] });
+      }
+    }
+    const origin = remotes.find((r) => r.name === "origin");
+    if (origin) {
+      const name = parseRepoName(origin.url + " ");
+      if (name)
+        return name;
+    }
+    for (const remote of remotes) {
+      const name = parseRepoName(remote.url + " ");
+      if (name)
+        return name;
+    }
+  } catch {
+  }
+  return void 0;
+}
+function loadConfig(options) {
+  const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
   const project = process.env.CC_LANGSMITH_PROJECT ?? "claude-code";
   const apiBaseUrl = process.env.LANGSMITH_ENDPOINT ?? "https://api.smith.langchain.com";
@@ -160,7 +202,13 @@ function loadConfig() {
   if (anthropicUserId) {
     identityMetadata.anthropic_user_id = anthropicUserId;
   }
-  customMetadata = { ...identityMetadata, ...customMetadata };
+  const repoMetadata = {};
+  const repoName = getRepoName(cwd);
+  if (repoName != null) {
+    repoMetadata.repository_name = repoName.name;
+    repoMetadata.repository_provider = repoName.provider;
+  }
+  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -803,7 +803,7 @@ function v7(options, buf, offset) {
 }
 var v7_default = v7;
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/constants.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/constants.js
 var GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 var GEN_AI_SYSTEM = "gen_ai.system";
 var GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -838,7 +838,7 @@ var LANGSMITH_TAGS = "langsmith.span.tags";
 var LANGSMITH_REQUEST_STREAMING = "langsmith.request.streaming";
 var LANGSMITH_REQUEST_HEADERS = "langsmith.request.headers";
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/env.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/env.js
 var globalEnv;
 var isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";
 var isWebWorker = () => typeof globalThis === "object" && globalThis.constructor && globalThis.constructor.name === "DedicatedWorkerGlobalScope";
@@ -978,7 +978,7 @@ function getOtelEnabled() {
   return getEnvironmentVariable("OTEL_ENABLED") === "true" || getLangSmithEnvironmentVariable("OTEL_ENABLED") === "true";
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/otel.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/otel.js
 var MockTracer = class {
   constructor() {
     Object.defineProperty(this, "hasWarned", {
@@ -1084,7 +1084,7 @@ function getDefaultOTLPTracerComponents() {
   return OTELProviderSingleton.getDefaultOTLPTracerComponents();
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/translator.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/translator.js
 var WELL_KNOWN_OPERATION_NAMES = {
   llm: "chat",
   tool: "execute_tool",
@@ -1425,7 +1425,7 @@ var LangSmithToOTELTranslator = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/is-network-error/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/is-network-error/index.js
 var objectToString = Object.prototype.toString;
 var isError = (value) => objectToString.call(value) === "[object Error]";
 var errorMessages = /* @__PURE__ */ new Set([
@@ -1464,7 +1464,7 @@ function isNetworkError(error2) {
   return errorMessages.has(message);
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-retry/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-retry/index.js
 function validateRetries(retries) {
   if (typeof retries === "number") {
     if (retries < 0) {
@@ -1637,11 +1637,11 @@ async function pRetry(input, options = {}) {
   throw new Error("Retry attempts exhausted without throwing an error.");
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-queue.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-queue.js
 var import_p_queue = __toESM(require_dist(), 1);
 var PQueue = "default" in import_p_queue.default ? import_p_queue.default.default : import_p_queue.default;
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/async_caller.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/async_caller.js
 var STATUS_RETRYABLE = [
   408,
   // Request Timeout
@@ -1769,7 +1769,7 @@ var AsyncCaller = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/messages.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/messages.js
 function isLangChainMessage(message) {
   return typeof message?._getType === "function";
 }
@@ -1784,7 +1784,7 @@ function convertLangChainMessageToExample(message) {
   return converted;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/warn.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/warn.js
 var warnedMessages = {};
 function warnOnce(message) {
   if (!warnedMessages[message]) {
@@ -1793,7 +1793,7 @@ function warnOnce(message) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/xxhash/xxhash.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/xxhash/xxhash.js
 var n = (n2) => BigInt(n2);
 var PRIME32_1 = n("0x9E3779B1");
 var PRIME32_2 = n("0x85EBCA77");
@@ -2073,7 +2073,7 @@ function xxh128ToBytes(hash128) {
   return result;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/_uuid.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/_uuid.js
 var UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function assertUuid(str, which) {
   if (!UUID_REGEX.test(str)) {
@@ -2135,7 +2135,7 @@ function nonCryptographicUuid7Deterministic(originalId, key) {
   return bytesToUuid(b);
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/error.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/error.js
 function getInvalidPromptIdentifierMsg(identifier) {
   return `Invalid prompt identifier format: "${identifier}". Expected one of:
   - "prompt-name" (for private prompts)
@@ -2228,7 +2228,7 @@ function isConflictingEndpointsError(err) {
   return typeof err === "object" && err !== null && err.code === ERR_CONFLICTING_ENDPOINTS;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompts.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompts.js
 function parsePromptIdentifier(identifier) {
   if (!identifier || identifier.split("/").length > 2 || identifier.startsWith("/") || identifier.endsWith("/") || identifier.split(":").length > 2) {
     throw new Error(getInvalidPromptIdentifierMsg(identifier));
@@ -2249,7 +2249,7 @@ function parsePromptIdentifier(identifier) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fs.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fs.js
 import * as nodeFs from "node:fs";
 import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
@@ -2290,7 +2290,7 @@ function readFileSync2(filePath) {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompt_cache/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompt_cache/index.js
 function isStale(entry, ttlSeconds) {
   if (ttlSeconds === null) {
     return false;
@@ -2564,7 +2564,7 @@ var PromptCache = class {
 };
 var promptCacheSingleton = new PromptCache();
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/fetch.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/fetch.js
 var DEFAULT_FETCH_IMPLEMENTATION = (...args) => fetch(...args);
 var globalFetchSupportsWebStreaming = void 0;
 var LANGSMITH_FETCH_IMPLEMENTATION_KEY = /* @__PURE__ */ Symbol.for("ls:fetch_implementation");
@@ -2589,7 +2589,7 @@ var _getFetchImplementation = (debug2) => {
   };
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
 var LIMIT_REPLACE_NODE = "[...]";
 var CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
 var arr = [];
@@ -2741,7 +2741,7 @@ function replaceGetterValues(replacer) {
   };
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/client.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/client.js
 function _ensureUTCTimestamp(ts) {
   if (typeof ts === "string" && ts.length > 0 && !ts.includes("Z") && !ts.includes("+") && !ts.includes("-", 10)) {
     return ts + "Z";
@@ -3305,6 +3305,22 @@ var Client = class _Client {
     }
     return outputs;
   }
+  /**
+   * Filter content from new_token events to prevent streaming LLM output
+   * from being uploaded via events.
+   */
+  _filterNewTokenEvents(events) {
+    if (!events || events.length === 0) {
+      return events;
+    }
+    return events.map((event) => {
+      if (event.name === "new_token") {
+        const { kwargs: _, ...rest } = event;
+        return rest;
+      }
+      return event;
+    });
+  }
   async prepareRunCreateOrUpdateInputs(run) {
     const runParams = { ...run };
     if (runParams.inputs !== void 0) {
@@ -3312,6 +3328,9 @@ var Client = class _Client {
     }
     if (runParams.outputs !== void 0) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
+    }
+    if (runParams.events !== void 0) {
+      runParams.events = this._filterNewTokenEvents(runParams.events);
     }
     return runParams;
   }
@@ -4072,6 +4091,9 @@ Context: ${context}`);
     }
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
+    }
+    if (run.events) {
+      run.events = this._filterNewTokenEvents(run.events);
     }
     const data = { ...run, id: runId };
     if (!this._filterForSampling([data], true).length) {
@@ -6933,7 +6955,7 @@ function isExampleCreate(input) {
   return "dataset_id" in input || "dataset_name" in input;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/env.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/env.js
 var isTracingEnabled = (tracingEnabled) => {
   if (tracingEnabled !== void 0) {
     return tracingEnabled;
@@ -6942,11 +6964,11 @@ var isTracingEnabled = (tracingEnabled) => {
   return !!envVars.find((envVar) => getLangSmithEnvironmentVariable(envVar) === "true");
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/constants.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/constants.js
 var _LC_CONTEXT_VARIABLES_KEY = /* @__PURE__ */ Symbol.for("lc:context_variables");
 var _REPLICA_TRACE_ROOTS_KEY = /* @__PURE__ */ Symbol.for("langsmith:replica_trace_roots");
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/context_vars.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/context_vars.js
 function getContextVar(runTree, key) {
   if (_LC_CONTEXT_VARIABLES_KEY in runTree) {
     const contextVars = runTree[_LC_CONTEXT_VARIABLES_KEY];
@@ -6963,13 +6985,13 @@ function setContextVar(runTree, key, value) {
   runTree[_LC_CONTEXT_VARIABLES_KEY] = contextVars;
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/project.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/project.js
 var getDefaultProjectName = () => {
   return getLangSmithEnvironmentVariable("PROJECT") ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? // TODO: Deprecate
   "default";
 };
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/run_trees.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/run_trees.js
 var TIMESTAMP_LENGTH = 36;
 var UUID_NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 function getReplicaKey(replica) {
@@ -7870,13 +7892,13 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/uuid.js
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/uuid.js
 function uuid7() {
   return v7_default();
 }
 
-// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/index.js
-var __version__ = "0.5.18";
+// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/index.js
+var __version__ = "0.5.19";
 
 // dist/logger.js
 import { appendFileSync, mkdirSync as mkdirSync3, statSync, renameSync as renameSync3 } from "node:fs";

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -803,7 +803,7 @@ function v7(options, buf, offset) {
 }
 var v7_default = v7;
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/constants.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/constants.js
 var GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 var GEN_AI_SYSTEM = "gen_ai.system";
 var GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -838,7 +838,7 @@ var LANGSMITH_TAGS = "langsmith.span.tags";
 var LANGSMITH_REQUEST_STREAMING = "langsmith.request.streaming";
 var LANGSMITH_REQUEST_HEADERS = "langsmith.request.headers";
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/env.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/env.js
 var globalEnv;
 var isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";
 var isWebWorker = () => typeof globalThis === "object" && globalThis.constructor && globalThis.constructor.name === "DedicatedWorkerGlobalScope";
@@ -978,7 +978,7 @@ function getOtelEnabled() {
   return getEnvironmentVariable("OTEL_ENABLED") === "true" || getLangSmithEnvironmentVariable("OTEL_ENABLED") === "true";
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/otel.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/otel.js
 var MockTracer = class {
   constructor() {
     Object.defineProperty(this, "hasWarned", {
@@ -1084,7 +1084,7 @@ function getDefaultOTLPTracerComponents() {
   return OTELProviderSingleton.getDefaultOTLPTracerComponents();
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/experimental/otel/translator.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/experimental/otel/translator.js
 var WELL_KNOWN_OPERATION_NAMES = {
   llm: "chat",
   tool: "execute_tool",
@@ -1425,7 +1425,7 @@ var LangSmithToOTELTranslator = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/is-network-error/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/is-network-error/index.js
 var objectToString = Object.prototype.toString;
 var isError = (value) => objectToString.call(value) === "[object Error]";
 var errorMessages = /* @__PURE__ */ new Set([
@@ -1464,7 +1464,7 @@ function isNetworkError(error2) {
   return errorMessages.has(message);
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-retry/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-retry/index.js
 function validateRetries(retries) {
   if (typeof retries === "number") {
     if (retries < 0) {
@@ -1637,11 +1637,11 @@ async function pRetry(input, options = {}) {
   throw new Error("Retry attempts exhausted without throwing an error.");
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/p-queue.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/p-queue.js
 var import_p_queue = __toESM(require_dist(), 1);
 var PQueue = "default" in import_p_queue.default ? import_p_queue.default.default : import_p_queue.default;
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/async_caller.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/async_caller.js
 var STATUS_RETRYABLE = [
   408,
   // Request Timeout
@@ -1769,7 +1769,7 @@ var AsyncCaller = class {
   }
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/messages.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/messages.js
 function isLangChainMessage(message) {
   return typeof message?._getType === "function";
 }
@@ -1784,7 +1784,7 @@ function convertLangChainMessageToExample(message) {
   return converted;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/warn.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/warn.js
 var warnedMessages = {};
 function warnOnce(message) {
   if (!warnedMessages[message]) {
@@ -1793,7 +1793,7 @@ function warnOnce(message) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/xxhash/xxhash.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/xxhash/xxhash.js
 var n = (n2) => BigInt(n2);
 var PRIME32_1 = n("0x9E3779B1");
 var PRIME32_2 = n("0x85EBCA77");
@@ -2073,7 +2073,7 @@ function xxh128ToBytes(hash128) {
   return result;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/_uuid.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/_uuid.js
 var UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function assertUuid(str, which) {
   if (!UUID_REGEX.test(str)) {
@@ -2135,7 +2135,7 @@ function nonCryptographicUuid7Deterministic(originalId, key) {
   return bytesToUuid(b);
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/error.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/error.js
 function getInvalidPromptIdentifierMsg(identifier) {
   return `Invalid prompt identifier format: "${identifier}". Expected one of:
   - "prompt-name" (for private prompts)
@@ -2228,7 +2228,7 @@ function isConflictingEndpointsError(err) {
   return typeof err === "object" && err !== null && err.code === ERR_CONFLICTING_ENDPOINTS;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompts.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompts.js
 function parsePromptIdentifier(identifier) {
   if (!identifier || identifier.split("/").length > 2 || identifier.startsWith("/") || identifier.endsWith("/") || identifier.split(":").length > 2) {
     throw new Error(getInvalidPromptIdentifierMsg(identifier));
@@ -2249,7 +2249,7 @@ function parsePromptIdentifier(identifier) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fs.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fs.js
 import * as nodeFs from "node:fs";
 import * as nodeFsPromises from "node:fs/promises";
 import * as nodePath from "node:path";
@@ -2290,7 +2290,7 @@ function readFileSync2(filePath) {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/prompt_cache/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/prompt_cache/index.js
 function isStale(entry, ttlSeconds) {
   if (ttlSeconds === null) {
     return false;
@@ -2564,7 +2564,7 @@ var PromptCache = class {
 };
 var promptCacheSingleton = new PromptCache();
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/fetch.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/fetch.js
 var DEFAULT_FETCH_IMPLEMENTATION = (...args) => fetch(...args);
 var globalFetchSupportsWebStreaming = void 0;
 var LANGSMITH_FETCH_IMPLEMENTATION_KEY = /* @__PURE__ */ Symbol.for("ls:fetch_implementation");
@@ -2589,7 +2589,7 @@ var _getFetchImplementation = (debug2) => {
   };
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/fast-safe-stringify/index.js
 var LIMIT_REPLACE_NODE = "[...]";
 var CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
 var arr = [];
@@ -2741,7 +2741,7 @@ function replaceGetterValues(replacer) {
   };
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/client.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/client.js
 function _ensureUTCTimestamp(ts) {
   if (typeof ts === "string" && ts.length > 0 && !ts.includes("Z") && !ts.includes("+") && !ts.includes("-", 10)) {
     return ts + "Z";
@@ -3305,22 +3305,6 @@ var Client = class _Client {
     }
     return outputs;
   }
-  /**
-   * Filter content from new_token events to prevent streaming LLM output
-   * from being uploaded via events.
-   */
-  _filterNewTokenEvents(events) {
-    if (!events || events.length === 0) {
-      return events;
-    }
-    return events.map((event) => {
-      if (event.name === "new_token") {
-        const { kwargs: _, ...rest } = event;
-        return rest;
-      }
-      return event;
-    });
-  }
   async prepareRunCreateOrUpdateInputs(run) {
     const runParams = { ...run };
     if (runParams.inputs !== void 0) {
@@ -3328,9 +3312,6 @@ var Client = class _Client {
     }
     if (runParams.outputs !== void 0) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
-    }
-    if (runParams.events !== void 0) {
-      runParams.events = this._filterNewTokenEvents(runParams.events);
     }
     return runParams;
   }
@@ -4091,9 +4072,6 @@ Context: ${context}`);
     }
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
-    }
-    if (run.events) {
-      run.events = this._filterNewTokenEvents(run.events);
     }
     const data = { ...run, id: runId };
     if (!this._filterForSampling([data], true).length) {
@@ -6955,7 +6933,7 @@ function isExampleCreate(input) {
   return "dataset_id" in input || "dataset_name" in input;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/env.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/env.js
 var isTracingEnabled = (tracingEnabled) => {
   if (tracingEnabled !== void 0) {
     return tracingEnabled;
@@ -6964,11 +6942,11 @@ var isTracingEnabled = (tracingEnabled) => {
   return !!envVars.find((envVar) => getLangSmithEnvironmentVariable(envVar) === "true");
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/singletons/constants.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/singletons/constants.js
 var _LC_CONTEXT_VARIABLES_KEY = /* @__PURE__ */ Symbol.for("lc:context_variables");
 var _REPLICA_TRACE_ROOTS_KEY = /* @__PURE__ */ Symbol.for("langsmith:replica_trace_roots");
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/context_vars.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/context_vars.js
 function getContextVar(runTree, key) {
   if (_LC_CONTEXT_VARIABLES_KEY in runTree) {
     const contextVars = runTree[_LC_CONTEXT_VARIABLES_KEY];
@@ -6985,13 +6963,13 @@ function setContextVar(runTree, key, value) {
   runTree[_LC_CONTEXT_VARIABLES_KEY] = contextVars;
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/utils/project.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/utils/project.js
 var getDefaultProjectName = () => {
   return getLangSmithEnvironmentVariable("PROJECT") ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? // TODO: Deprecate
   "default";
 };
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/run_trees.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/run_trees.js
 var TIMESTAMP_LENGTH = 36;
 var UUID_NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 function getReplicaKey(replica) {
@@ -7892,13 +7870,13 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/uuid.js
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/uuid.js
 function uuid7() {
   return v7_default();
 }
 
-// node_modules/.pnpm/langsmith@0.5.19/node_modules/langsmith/dist/index.js
-var __version__ = "0.5.19";
+// node_modules/.pnpm/langsmith@0.5.18/node_modules/langsmith/dist/index.js
+var __version__ = "0.5.18";
 
 // dist/logger.js
 import { appendFileSync, mkdirSync as mkdirSync3, statSync, renameSync as renameSync3 } from "node:fs";
@@ -8698,6 +8676,7 @@ async function tracePendingSubagents(options) {
 import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -8718,7 +8697,48 @@ function readAnthropicUserId() {
 function readLocalUsername() {
   return userInfo().username;
 }
-function loadConfig() {
+var GIT_PROVIDERS_REGEX = {
+  github: /[@/](?:github\.com)[:/](.+?)(?:\.git)?\s/,
+  gitlab: /[@/](?:gitlab\.com)[:/](.+?)(?:\.git)?\s/,
+  bitbucket: /[@/](?:bitbucket\.org)[:/](.+?)(?:\.git)?\s/,
+  devAzure: /[@/](?:dev\.azure\.com)[:/](.+?)(?:\.git)?\s/
+};
+function parseRepoName(remoteUrl) {
+  for (const [provider, regex] of Object.entries(GIT_PROVIDERS_REGEX)) {
+    const match = remoteUrl.match(regex);
+    if (match)
+      return { provider, name: match[1] };
+  }
+  return void 0;
+}
+function getRepoName(cwd) {
+  try {
+    const output = execSync("git remote -v", { cwd, encoding: "utf-8", timeout: 5e3 });
+    const lines = output.trim().split("\n").filter(Boolean);
+    const remotes = [];
+    for (const line of lines) {
+      const parts = line.split(/\s+/);
+      if (parts.length >= 2 && line.includes("(fetch)")) {
+        remotes.push({ name: parts[0], url: parts[1] });
+      }
+    }
+    const origin = remotes.find((r) => r.name === "origin");
+    if (origin) {
+      const name = parseRepoName(origin.url + " ");
+      if (name)
+        return name;
+    }
+    for (const remote of remotes) {
+      const name = parseRepoName(remote.url + " ");
+      if (name)
+        return name;
+    }
+  } catch {
+  }
+  return void 0;
+}
+function loadConfig(options) {
+  const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
   const project = process.env.CC_LANGSMITH_PROJECT ?? "claude-code";
   const apiBaseUrl = process.env.LANGSMITH_ENDPOINT ?? "https://api.smith.langchain.com";
@@ -8755,7 +8775,13 @@ function loadConfig() {
   if (anthropicUserId) {
     identityMetadata.anthropic_user_id = anthropicUserId;
   }
-  customMetadata = { ...identityMetadata, ...customMetadata };
+  const repoMetadata = {};
+  const repoName = getRepoName(cwd);
+  if (repoName != null) {
+    repoMetadata.repository_name = repoName.name;
+    repoMetadata.repository_provider = repoName.provider;
+  }
+  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -3,10 +3,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { loadConfig } from "./config.js";
+import { execSync } from "node:child_process";
+
+vi.mock("node:child_process", { spy: true });
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("loadConfig", () => {
   const originalEnv = { ...process.env };
   let tmpHome: string;
+  const cwd = "/tmp/langsmith-claude-code-plugins/cwd";
 
   beforeEach(() => {
     // Clear relevant env vars
@@ -36,58 +44,58 @@ describe("loadConfig", () => {
   it("reads CC_LANGSMITH_API_KEY first", () => {
     process.env.CC_LANGSMITH_API_KEY = "cc-key";
     process.env.LANGSMITH_API_KEY = "fallback-key";
-    expect(loadConfig().apiKey).toBe("cc-key");
+    expect(loadConfig({ cwd }).apiKey).toBe("cc-key");
   });
 
   it("falls back to LANGSMITH_API_KEY", () => {
     process.env.LANGSMITH_API_KEY = "fallback-key";
-    expect(loadConfig().apiKey).toBe("fallback-key");
+    expect(loadConfig({ cwd }).apiKey).toBe("fallback-key");
   });
 
   it("returns empty string when no API key set", () => {
-    expect(loadConfig().apiKey).toBe("");
+    expect(loadConfig({ cwd }).apiKey).toBe("");
   });
 
   it("defaults project to 'claude-code'", () => {
-    expect(loadConfig().project).toBe("claude-code");
+    expect(loadConfig({ cwd }).project).toBe("claude-code");
   });
 
   it("reads custom project name", () => {
     process.env.CC_LANGSMITH_PROJECT = "my-project";
-    expect(loadConfig().project).toBe("my-project");
+    expect(loadConfig({ cwd }).project).toBe("my-project");
   });
 
   it("defaults API base URL", () => {
-    expect(loadConfig().apiBaseUrl).toBe("https://api.smith.langchain.com");
+    expect(loadConfig({ cwd }).apiBaseUrl).toBe("https://api.smith.langchain.com");
   });
 
   it("reads custom API base URL", () => {
     process.env.LANGSMITH_ENDPOINT = "https://custom.api.com";
-    expect(loadConfig().apiBaseUrl).toBe("https://custom.api.com");
+    expect(loadConfig({ cwd }).apiBaseUrl).toBe("https://custom.api.com");
   });
 
   it("reads custom state file path", () => {
     process.env.STATE_FILE = "/custom/state.json";
-    expect(loadConfig().stateFilePath).toBe("/custom/state.json");
+    expect(loadConfig({ cwd }).stateFilePath).toBe("/custom/state.json");
   });
 
   it("defaults debug to false", () => {
-    expect(loadConfig().debug).toBe(false);
+    expect(loadConfig({ cwd }).debug).toBe(false);
   });
 
   it("enables debug with 'true'", () => {
     process.env.CC_LANGSMITH_DEBUG = "true";
-    expect(loadConfig().debug).toBe(true);
+    expect(loadConfig({ cwd }).debug).toBe(true);
   });
 
   it("enables debug case-insensitively", () => {
     process.env.CC_LANGSMITH_DEBUG = "TRUE";
-    expect(loadConfig().debug).toBe(true);
+    expect(loadConfig({ cwd }).debug).toBe(true);
   });
 
   it("does not enable debug with other values", () => {
     process.env.CC_LANGSMITH_DEBUG = "1";
-    expect(loadConfig().debug).toBe(false);
+    expect(loadConfig({ cwd }).debug).toBe(false);
   });
 
   it("parses CC_LANGSMITH_RUNS_ENDPOINTS as JSON array", () => {
@@ -98,7 +106,7 @@ describe("loadConfig", () => {
         projectName: "project-prod",
       },
     ]);
-    const config = loadConfig();
+    const config = loadConfig({ cwd });
     expect(config.replicas).toBeDefined();
     expect(config.replicas).toHaveLength(1);
     expect(config.replicas?.[0]).toEqual({
@@ -122,20 +130,20 @@ describe("loadConfig", () => {
         updates: { metadata: { environment: "staging" } },
       },
     ]);
-    const config = loadConfig();
+    const config = loadConfig({ cwd });
     expect(config.replicas).toHaveLength(2);
     expect(config.replicas?.[1].updates).toEqual({ metadata: { environment: "staging" } });
   });
 
   it("returns undefined replicas when CC_LANGSMITH_RUNS_ENDPOINTS not set", () => {
-    expect(loadConfig().replicas).toBeUndefined();
+    expect(loadConfig({ cwd }).replicas).toBeUndefined();
   });
 
   it("handles invalid JSON in CC_LANGSMITH_RUNS_ENDPOINTS gracefully", () => {
     const originalError = console.error;
     console.error = vi.fn();
     process.env.CC_LANGSMITH_RUNS_ENDPOINTS = "not valid json";
-    const config = loadConfig();
+    const config = loadConfig({ cwd });
     // Should not throw and replicas should be undefined
     expect(config.replicas).toBeUndefined();
     console.error = originalError;
@@ -146,7 +154,7 @@ describe("loadConfig", () => {
       pr_url: "https://github.com/org/repo/pull/42",
       pr_author: "octocat",
     });
-    const config = loadConfig();
+    const config = loadConfig({ cwd });
     expect(config.customMetadata).toMatchObject({
       pr_url: "https://github.com/org/repo/pull/42",
       pr_author: "octocat",
@@ -155,7 +163,7 @@ describe("loadConfig", () => {
   });
 
   it("populates customMetadata with identity fields when CC_LANGSMITH_METADATA not set", () => {
-    const config = loadConfig();
+    const config = loadConfig({ cwd });
     // local_username always resolves (at minimum to "unknown")
     expect(config.customMetadata?.local_username).toEqual(expect.any(String));
   });
@@ -164,7 +172,7 @@ describe("loadConfig", () => {
     const originalError = console.error;
     console.error = vi.fn();
     process.env.CC_LANGSMITH_METADATA = "not valid json";
-    const config = loadConfig();
+    const config = loadConfig({ cwd });
     // Falls back to identity-only metadata
     expect(config.customMetadata).toMatchObject({ local_username: expect.any(String) });
     expect(config.customMetadata).not.toHaveProperty("anthropic_user_id");
@@ -175,7 +183,7 @@ describe("loadConfig", () => {
     const originalError = console.error;
     console.error = vi.fn();
     process.env.CC_LANGSMITH_METADATA = '["not", "an", "object"]';
-    const config = loadConfig();
+    const config = loadConfig({ cwd });
     expect(config.customMetadata).toMatchObject({ local_username: expect.any(String) });
     console.error = originalError;
   });
@@ -184,7 +192,7 @@ describe("loadConfig", () => {
     const originalError = console.error;
     console.error = vi.fn();
     process.env.CC_LANGSMITH_METADATA = '"just a string"';
-    const config = loadConfig();
+    const config = loadConfig({ cwd });
     expect(config.customMetadata).toMatchObject({ local_username: expect.any(String) });
     console.error = originalError;
   });
@@ -195,7 +203,7 @@ describe("loadConfig", () => {
         join(tmpHome, ".claude.json"),
         JSON.stringify({ userID: "abc123hashed_user_id" }),
       );
-      const config = loadConfig();
+      const config = loadConfig({ cwd });
       expect(config.customMetadata).toMatchObject({
         anthropic_user_id: "abc123hashed_user_id",
         local_username: expect.any(String),
@@ -205,7 +213,7 @@ describe("loadConfig", () => {
     it("merges anthropic_user_id with CC_LANGSMITH_METADATA", () => {
       writeFileSync(join(tmpHome, ".claude.json"), JSON.stringify({ userID: "user-xyz" }));
       process.env.CC_LANGSMITH_METADATA = JSON.stringify({ pr_author: "octocat" });
-      const config = loadConfig();
+      const config = loadConfig({ cwd });
       expect(config.customMetadata).toMatchObject({
         anthropic_user_id: "user-xyz",
         pr_author: "octocat",
@@ -216,13 +224,13 @@ describe("loadConfig", () => {
     it("user-supplied CC_LANGSMITH_METADATA overrides anthropic_user_id on conflict", () => {
       writeFileSync(join(tmpHome, ".claude.json"), JSON.stringify({ userID: "auto-id" }));
       process.env.CC_LANGSMITH_METADATA = JSON.stringify({ anthropic_user_id: "manual-id" });
-      const config = loadConfig();
+      const config = loadConfig({ cwd });
       expect(config.customMetadata?.anthropic_user_id).toBe("manual-id");
     });
 
     it("omits anthropic_user_id when ~/.claude.json is missing", () => {
       // tmpHome is empty
-      const config = loadConfig();
+      const config = loadConfig({ cwd });
       expect(config.customMetadata).not.toHaveProperty("anthropic_user_id");
       expect(config.customMetadata).toMatchObject({ local_username: expect.any(String) });
     });
@@ -245,7 +253,7 @@ describe("loadConfig", () => {
 
   describe("local username", () => {
     it("includes local_username in customMetadata", () => {
-      const config = loadConfig();
+      const config = loadConfig({ cwd });
       const username = config.customMetadata?.local_username;
       expect(typeof username).toBe("string");
       expect((username as string).length).toBeGreaterThan(0);
@@ -253,8 +261,34 @@ describe("loadConfig", () => {
 
     it("user-supplied CC_LANGSMITH_METADATA overrides local_username on conflict", () => {
       process.env.CC_LANGSMITH_METADATA = JSON.stringify({ local_username: "custom-name" });
-      const config = loadConfig();
+      const config = loadConfig({ cwd });
       expect(config.customMetadata?.local_username).toBe("custom-name");
+    });
+  });
+
+  it.each([
+    ["github", "https://github.com/langchain-ai/example.git"],
+    ["gitlab", "https://gitlab.com/langchain-ai/example.git"],
+    ["bitbucket", "https://bitbucket.org/langchain-ai/example.git"],
+    ["devAzure", "https://dev.azure.com/langchain-ai/example.git"],
+  ])("inserts repository name into customMetadata for %s", (provider, url) => {
+    vi.mocked(execSync).mockImplementation(() => {
+      return [["origin", url + " (fetch)"].join("\t"), ["origin", url + " (push)"].join("\t")].join(
+        "\n",
+      );
+    });
+
+    process.env.CC_LANGSMITH_METADATA = JSON.stringify({
+      pr_url: "https://github.com/org/repo/pull/42",
+      pr_author: "octocat",
+    });
+
+    const config = loadConfig({ cwd: __dirname });
+    expect(config.customMetadata).toMatchObject({
+      pr_url: "https://github.com/org/repo/pull/42",
+      pr_author: "octocat",
+      repository_name: "langchain-ai/example",
+      repository_provider: provider,
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { userInfo } from "node:os";
 import { join } from "node:path";
 import type { RunTreeConfig } from "langsmith";
 import { debug, error } from "./logger.js";
+import { execSync } from "node:child_process";
 
 /**
  * Configuration — reads from environment variables.
@@ -52,7 +53,66 @@ export interface Config {
   customMetadata?: Record<string, unknown>;
 }
 
-export function loadConfig(): Config {
+/**
+ * Extract repo name (owner/repo) from a git remote URL.
+ * Supports HTTPS, SSH, and git@ URL formats for common hosts
+ * (github.com, gitlab.com, bitbucket.org, etc.).
+ */
+
+const GIT_PROVIDERS_REGEX = {
+  github: /[@/](?:github\.com)[:/](.+?)(?:\.git)?\s/,
+  gitlab: /[@/](?:gitlab\.com)[:/](.+?)(?:\.git)?\s/,
+  bitbucket: /[@/](?:bitbucket\.org)[:/](.+?)(?:\.git)?\s/,
+  devAzure: /[@/](?:dev\.azure\.com)[:/](.+?)(?:\.git)?\s/,
+};
+
+export function parseRepoName(remoteUrl: string): { provider: string; name: string } | undefined {
+  // Match git@host:owner/repo.git or ssh://git@host/owner/repo.git
+  for (const [provider, regex] of Object.entries(GIT_PROVIDERS_REGEX)) {
+    const match = remoteUrl.match(regex);
+    if (match) return { provider, name: match[1] };
+  }
+  return undefined;
+}
+
+/**
+ * Detect the git repo name from remotes in the given directory.
+ * Gives precedence to "origin", then picks the first remote matching a known host.
+ */
+export function getRepoName(cwd: string): { provider: string; name: string } | undefined {
+  try {
+    const output = execSync("git remote -v", { cwd, encoding: "utf-8", timeout: 5000 });
+    const lines = output.trim().split("\n").filter(Boolean);
+
+    // Parse all remotes: [name, url, type]
+    const remotes: Array<{ name: string; url: string }> = [];
+    for (const line of lines) {
+      const parts = line.split(/\s+/);
+      if (parts.length >= 2 && line.includes("(fetch)")) {
+        remotes.push({ name: parts[0], url: parts[1] });
+      }
+    }
+
+    // Prefer "origin"
+    const origin = remotes.find((r) => r.name === "origin");
+    if (origin) {
+      const name = parseRepoName(origin.url + " ");
+      if (name) return name;
+    }
+
+    // Fall back to first remote that matches a known host
+    for (const remote of remotes) {
+      const name = parseRepoName(remote.url + " ");
+      if (name) return name;
+    }
+  } catch {
+    // Not a git repo or git not available — silently skip
+  }
+  return undefined;
+}
+
+export function loadConfig(options?: { cwd?: string }): Config {
+  const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
 
   const project = process.env.CC_LANGSMITH_PROJECT ?? "claude-code";
@@ -102,7 +162,16 @@ export function loadConfig(): Config {
   if (anthropicUserId) {
     identityMetadata.anthropic_user_id = anthropicUserId;
   }
-  customMetadata = { ...identityMetadata, ...customMetadata };
+
+  // Attach git repo metadata if available, to attribute runs to a specific codebase.
+  const repoMetadata: Record<string, unknown> = {};
+  const repoName = getRepoName(cwd);
+  if (repoName != null) {
+    repoMetadata.repository_name = repoName.name;
+    repoMetadata.repository_provider = repoName.provider;
+  }
+
+  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
 
   return {
     apiKey,


### PR DESCRIPTION
Send repository name and provider metadata to LangSmith, detected via `git remote`
