### PR TITLE
feat(claude-code): emit semantic metadata for tool calls [LSEN-272] 

### DIFF
--- a/bundle/post-tool-use.js
+++ b/bundle/post-tool-use.js
@@ -8003,6 +8003,80 @@ function getSessionState(state, sessionId) {
 }
 var SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 
+// dist/tool-metadata.js
+var FILE_OPERATION = {
+  Read: "read",
+  Write: "write",
+  Edit: "edit",
+  NotebookEdit: "edit"
+};
+function getFilePath(input) {
+  for (const key of ["file_path", "notebook_path"]) {
+    const value = input[key];
+    if (typeof value === "string" && value.length > 0)
+      return value;
+  }
+  return void 0;
+}
+function matchSkillPath(path2) {
+  const segments = path2.split("/").filter((segment) => segment.length > 0);
+  const idx = segments.indexOf("skills");
+  if (idx === -1)
+    return void 0;
+  const skillName = segments[idx + 1];
+  const relativeSegments = segments.slice(idx + 2);
+  if (!skillName || relativeSegments.length === 0)
+    return void 0;
+  return { skillName, relativeSegments };
+}
+function classifyToolCall(toolName, input) {
+  const safeInput = input ?? {};
+  if (toolName === "Skill") {
+    const skill = safeInput.skill;
+    return {
+      ls_event_kind: "skill_load",
+      ls_resource_kind: "skill",
+      ls_skill_detection: "explicit",
+      ...typeof skill === "string" && skill.length > 0 ? { ls_skill_name: skill } : {}
+    };
+  }
+  const fileOperation = FILE_OPERATION[toolName];
+  if (!fileOperation)
+    return {};
+  const path2 = getFilePath(safeInput);
+  if (!path2)
+    return {};
+  const skillPath = matchSkillPath(path2);
+  if (!skillPath) {
+    return { ls_resource_kind: "file", ls_file_operation: fileOperation };
+  }
+  const { skillName, relativeSegments } = skillPath;
+  if (fileOperation === "read") {
+    const isManifest = relativeSegments.length === 1 && relativeSegments[0] === "SKILL.md";
+    if (isManifest) {
+      return {
+        ls_event_kind: "skill_load",
+        ls_resource_kind: "skill",
+        ls_file_operation: "read",
+        ls_skill_name: skillName,
+        ls_skill_detection: "inferred"
+      };
+    }
+    return {
+      ls_event_kind: "skill_file_access",
+      ls_resource_kind: "skill_file",
+      ls_file_operation: "read",
+      ls_skill_name: skillName
+    };
+  }
+  return {
+    ls_event_kind: "skill_file_mutation",
+    ls_resource_kind: "skill_file",
+    ls_file_operation: fileOperation,
+    ls_skill_name: skillName
+  };
+}
+
 // dist/langsmith.js
 var client = void 0;
 var replicas = void 0;
@@ -8233,6 +8307,7 @@ async function main() {
           thread_id: input.session_id,
           ls_integration: "claude-code",
           tool_name: input.tool_name,
+          ...classifyToolCall(input.tool_name, input.tool_input),
           ...config.customMetadata
         }
       }

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -8229,6 +8229,80 @@ var SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 var USER_PROMPT_TURN_NAME = "Claude Code Turn";
 var ASSISTANT_RUN_NAME = "Claude";
 
+// dist/tool-metadata.js
+var FILE_OPERATION = {
+  Read: "read",
+  Write: "write",
+  Edit: "edit",
+  NotebookEdit: "edit"
+};
+function getFilePath(input) {
+  for (const key of ["file_path", "notebook_path"]) {
+    const value = input[key];
+    if (typeof value === "string" && value.length > 0)
+      return value;
+  }
+  return void 0;
+}
+function matchSkillPath(path2) {
+  const segments = path2.split("/").filter((segment) => segment.length > 0);
+  const idx = segments.indexOf("skills");
+  if (idx === -1)
+    return void 0;
+  const skillName = segments[idx + 1];
+  const relativeSegments = segments.slice(idx + 2);
+  if (!skillName || relativeSegments.length === 0)
+    return void 0;
+  return { skillName, relativeSegments };
+}
+function classifyToolCall(toolName, input) {
+  const safeInput = input ?? {};
+  if (toolName === "Skill") {
+    const skill = safeInput.skill;
+    return {
+      ls_event_kind: "skill_load",
+      ls_resource_kind: "skill",
+      ls_skill_detection: "explicit",
+      ...typeof skill === "string" && skill.length > 0 ? { ls_skill_name: skill } : {}
+    };
+  }
+  const fileOperation = FILE_OPERATION[toolName];
+  if (!fileOperation)
+    return {};
+  const path2 = getFilePath(safeInput);
+  if (!path2)
+    return {};
+  const skillPath = matchSkillPath(path2);
+  if (!skillPath) {
+    return { ls_resource_kind: "file", ls_file_operation: fileOperation };
+  }
+  const { skillName, relativeSegments } = skillPath;
+  if (fileOperation === "read") {
+    const isManifest = relativeSegments.length === 1 && relativeSegments[0] === "SKILL.md";
+    if (isManifest) {
+      return {
+        ls_event_kind: "skill_load",
+        ls_resource_kind: "skill",
+        ls_file_operation: "read",
+        ls_skill_name: skillName,
+        ls_skill_detection: "inferred"
+      };
+    }
+    return {
+      ls_event_kind: "skill_file_access",
+      ls_resource_kind: "skill_file",
+      ls_file_operation: "read",
+      ls_skill_name: skillName
+    };
+  }
+  return {
+    ls_event_kind: "skill_file_mutation",
+    ls_resource_kind: "skill_file",
+    ls_file_operation: fileOperation,
+    ls_skill_name: skillName
+  };
+}
+
 // dist/langsmith.js
 var client = void 0;
 var replicas = void 0;
@@ -8379,7 +8453,12 @@ async function traceTurn(options) {
         trace_id: traceId,
         dotted_order: toolDottedOrder,
         extra: {
-          metadata: { thread_id: sessionId, ls_integration: "claude-code", ...customMetadata }
+          metadata: {
+            thread_id: sessionId,
+            ls_integration: "claude-code",
+            ...classifyToolCall(toolCall.tool_use.name, toolCall.tool_use.input),
+            ...customMetadata
+          }
         }
       });
       await runTree2.postRun();

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -8259,6 +8259,80 @@ var __version__ = "0.5.19";
 var USER_PROMPT_TURN_NAME = "Claude Code Turn";
 var ASSISTANT_RUN_NAME = "Claude";
 
+// dist/tool-metadata.js
+var FILE_OPERATION = {
+  Read: "read",
+  Write: "write",
+  Edit: "edit",
+  NotebookEdit: "edit"
+};
+function getFilePath(input) {
+  for (const key of ["file_path", "notebook_path"]) {
+    const value = input[key];
+    if (typeof value === "string" && value.length > 0)
+      return value;
+  }
+  return void 0;
+}
+function matchSkillPath(path2) {
+  const segments = path2.split("/").filter((segment) => segment.length > 0);
+  const idx = segments.indexOf("skills");
+  if (idx === -1)
+    return void 0;
+  const skillName = segments[idx + 1];
+  const relativeSegments = segments.slice(idx + 2);
+  if (!skillName || relativeSegments.length === 0)
+    return void 0;
+  return { skillName, relativeSegments };
+}
+function classifyToolCall(toolName, input) {
+  const safeInput = input ?? {};
+  if (toolName === "Skill") {
+    const skill = safeInput.skill;
+    return {
+      ls_event_kind: "skill_load",
+      ls_resource_kind: "skill",
+      ls_skill_detection: "explicit",
+      ...typeof skill === "string" && skill.length > 0 ? { ls_skill_name: skill } : {}
+    };
+  }
+  const fileOperation = FILE_OPERATION[toolName];
+  if (!fileOperation)
+    return {};
+  const path2 = getFilePath(safeInput);
+  if (!path2)
+    return {};
+  const skillPath = matchSkillPath(path2);
+  if (!skillPath) {
+    return { ls_resource_kind: "file", ls_file_operation: fileOperation };
+  }
+  const { skillName, relativeSegments } = skillPath;
+  if (fileOperation === "read") {
+    const isManifest = relativeSegments.length === 1 && relativeSegments[0] === "SKILL.md";
+    if (isManifest) {
+      return {
+        ls_event_kind: "skill_load",
+        ls_resource_kind: "skill",
+        ls_file_operation: "read",
+        ls_skill_name: skillName,
+        ls_skill_detection: "inferred"
+      };
+    }
+    return {
+      ls_event_kind: "skill_file_access",
+      ls_resource_kind: "skill_file",
+      ls_file_operation: "read",
+      ls_skill_name: skillName
+    };
+  }
+  return {
+    ls_event_kind: "skill_file_mutation",
+    ls_resource_kind: "skill_file",
+    ls_file_operation: fileOperation,
+    ls_skill_name: skillName
+  };
+}
+
 // dist/langsmith.js
 var client = void 0;
 var replicas = void 0;
@@ -8409,7 +8483,12 @@ async function traceTurn(options) {
         trace_id: traceId,
         dotted_order: toolDottedOrder,
         extra: {
-          metadata: { thread_id: sessionId, ls_integration: "claude-code", ...customMetadata }
+          metadata: {
+            thread_id: sessionId,
+            ls_integration: "claude-code",
+            ...classifyToolCall(toolCall.tool_use.name, toolCall.tool_use.input),
+            ...customMetadata
+          }
         }
       });
       await runTree2.postRun();

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -8268,6 +8268,80 @@ var SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 var USER_PROMPT_TURN_NAME = "Claude Code Turn";
 var ASSISTANT_RUN_NAME = "Claude";
 
+// dist/tool-metadata.js
+var FILE_OPERATION = {
+  Read: "read",
+  Write: "write",
+  Edit: "edit",
+  NotebookEdit: "edit"
+};
+function getFilePath(input) {
+  for (const key of ["file_path", "notebook_path"]) {
+    const value = input[key];
+    if (typeof value === "string" && value.length > 0)
+      return value;
+  }
+  return void 0;
+}
+function matchSkillPath(path2) {
+  const segments = path2.split("/").filter((segment) => segment.length > 0);
+  const idx = segments.indexOf("skills");
+  if (idx === -1)
+    return void 0;
+  const skillName = segments[idx + 1];
+  const relativeSegments = segments.slice(idx + 2);
+  if (!skillName || relativeSegments.length === 0)
+    return void 0;
+  return { skillName, relativeSegments };
+}
+function classifyToolCall(toolName, input) {
+  const safeInput = input ?? {};
+  if (toolName === "Skill") {
+    const skill = safeInput.skill;
+    return {
+      ls_event_kind: "skill_load",
+      ls_resource_kind: "skill",
+      ls_skill_detection: "explicit",
+      ...typeof skill === "string" && skill.length > 0 ? { ls_skill_name: skill } : {}
+    };
+  }
+  const fileOperation = FILE_OPERATION[toolName];
+  if (!fileOperation)
+    return {};
+  const path2 = getFilePath(safeInput);
+  if (!path2)
+    return {};
+  const skillPath = matchSkillPath(path2);
+  if (!skillPath) {
+    return { ls_resource_kind: "file", ls_file_operation: fileOperation };
+  }
+  const { skillName, relativeSegments } = skillPath;
+  if (fileOperation === "read") {
+    const isManifest = relativeSegments.length === 1 && relativeSegments[0] === "SKILL.md";
+    if (isManifest) {
+      return {
+        ls_event_kind: "skill_load",
+        ls_resource_kind: "skill",
+        ls_file_operation: "read",
+        ls_skill_name: skillName,
+        ls_skill_detection: "inferred"
+      };
+    }
+    return {
+      ls_event_kind: "skill_file_access",
+      ls_resource_kind: "skill_file",
+      ls_file_operation: "read",
+      ls_skill_name: skillName
+    };
+  }
+  return {
+    ls_event_kind: "skill_file_mutation",
+    ls_resource_kind: "skill_file",
+    ls_file_operation: fileOperation,
+    ls_skill_name: skillName
+  };
+}
+
 // dist/langsmith.js
 var client = void 0;
 var replicas = void 0;
@@ -8428,7 +8502,12 @@ async function traceTurn(options) {
         trace_id: traceId,
         dotted_order: toolDottedOrder,
         extra: {
-          metadata: { thread_id: sessionId, ls_integration: "claude-code", ...customMetadata }
+          metadata: {
+            thread_id: sessionId,
+            ls_integration: "claude-code",
+            ...classifyToolCall(toolCall.tool_use.name, toolCall.tool_use.input),
+            ...customMetadata
+          }
         }
       });
       await runTree2.postRun();

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -13,6 +13,7 @@ import { initTracing, generateDottedOrderSegment, flushPendingTraces } from "../
 import { loadState, atomicUpdateState, getSessionState } from "../state.js";
 import { initHook } from "../utils/hook-init.js";
 import { readStdin } from "../utils/stdin.js";
+import { classifyToolCall } from "../tool-metadata.js";
 
 interface PostToolUseHookInput {
   session_id: string;
@@ -97,6 +98,7 @@ async function main(): Promise<void> {
           thread_id: input.session_id,
           ls_integration: "claude-code",
           tool_name: input.tool_name,
+          ...classifyToolCall(input.tool_name, input.tool_input),
           ...config.customMetadata,
         },
       },

--- a/src/langsmith.ts
+++ b/src/langsmith.ts
@@ -12,6 +12,7 @@ import { readTranscript, groupIntoTurns } from "./transcript.js";
 import { loadState, getSessionState } from "./state.js";
 import * as logger from "./logger.js";
 import { ASSISTANT_RUN_NAME, USER_PROMPT_TURN_NAME } from "./constants.js";
+import { classifyToolCall } from "./tool-metadata.js";
 
 // ─── Client setup ───────────────────────────────────────────────────────────
 
@@ -308,7 +309,12 @@ export async function traceTurn(
         trace_id: traceId,
         dotted_order: toolDottedOrder,
         extra: {
-          metadata: { thread_id: sessionId, ls_integration: "claude-code", ...customMetadata },
+          metadata: {
+            thread_id: sessionId,
+            ls_integration: "claude-code",
+            ...classifyToolCall(toolCall.tool_use.name, toolCall.tool_use.input),
+            ...customMetadata,
+          },
         },
       });
       await runTree.postRun();

--- a/src/tool-metadata.test.ts
+++ b/src/tool-metadata.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { classifyToolCall } from "./tool-metadata.js";
+
+describe("classifyToolCall", () => {
+  it("marks explicit Skill calls as skill loads with the skill name", () => {
+    expect(classifyToolCall("Skill", { skill: "code-review" })).toEqual({
+      ls_event_kind: "skill_load",
+      ls_resource_kind: "skill",
+      ls_skill_detection: "explicit",
+      ls_skill_name: "code-review",
+    });
+  });
+
+  it("handles Skill calls with no skill name", () => {
+    expect(classifyToolCall("Skill", {})).toEqual({
+      ls_event_kind: "skill_load",
+      ls_resource_kind: "skill",
+      ls_skill_detection: "explicit",
+    });
+  });
+
+  it("marks Read of a SKILL.md as an inferred skill load", () => {
+    expect(
+      classifyToolCall("Read", { file_path: "/home/u/.claude/skills/verify/SKILL.md" }),
+    ).toEqual({
+      ls_event_kind: "skill_load",
+      ls_resource_kind: "skill",
+      ls_file_operation: "read",
+      ls_skill_name: "verify",
+      ls_skill_detection: "inferred",
+    });
+  });
+
+  it("marks Read of other files under a skill dir as skill file access", () => {
+    expect(
+      classifyToolCall("Read", { file_path: "/home/u/skills/verify/scripts/run.sh" }),
+    ).toEqual({
+      ls_event_kind: "skill_file_access",
+      ls_resource_kind: "skill_file",
+      ls_file_operation: "read",
+      ls_skill_name: "verify",
+    });
+  });
+
+  it("marks Write under a skill dir as skill file mutation", () => {
+    expect(
+      classifyToolCall("Write", { file_path: "/home/u/skills/verify/SKILL.md" }),
+    ).toEqual({
+      ls_event_kind: "skill_file_mutation",
+      ls_resource_kind: "skill_file",
+      ls_file_operation: "write",
+      ls_skill_name: "verify",
+    });
+  });
+
+  it("marks Edit under a skill dir as skill file mutation", () => {
+    expect(
+      classifyToolCall("Edit", { file_path: "/home/u/skills/verify/notes.md" }),
+    ).toEqual({
+      ls_event_kind: "skill_file_mutation",
+      ls_resource_kind: "skill_file",
+      ls_file_operation: "edit",
+      ls_skill_name: "verify",
+    });
+  });
+
+  it("gives general file operations plain file metadata", () => {
+    expect(classifyToolCall("Read", { file_path: "/src/index.ts" })).toEqual({
+      ls_resource_kind: "file",
+      ls_file_operation: "read",
+    });
+    expect(classifyToolCall("Write", { file_path: "/src/index.ts" })).toEqual({
+      ls_resource_kind: "file",
+      ls_file_operation: "write",
+    });
+    expect(classifyToolCall("Edit", { file_path: "/src/index.ts" })).toEqual({
+      ls_resource_kind: "file",
+      ls_file_operation: "edit",
+    });
+  });
+
+  it("uses segment matching, not substring matching", () => {
+    // "skills" appears as a substring but not as a path segment.
+    expect(
+      classifyToolCall("Read", { file_path: "/src/my-skills-helper/index.ts" }),
+    ).toEqual({
+      ls_resource_kind: "file",
+      ls_file_operation: "read",
+    });
+  });
+
+  it("ignores a trailing skills directory with no skill under it", () => {
+    expect(classifyToolCall("Read", { file_path: "/home/u/skills" })).toEqual({
+      ls_resource_kind: "file",
+      ls_file_operation: "read",
+    });
+  });
+
+  it("returns no semantic metadata for unrelated tools", () => {
+    expect(classifyToolCall("Bash", { command: "ls" })).toEqual({});
+    expect(classifyToolCall("Read", {})).toEqual({});
+  });
+});

--- a/src/tool-metadata.ts
+++ b/src/tool-metadata.ts
@@ -1,0 +1,103 @@
+/**
+ * Derives normalized, queryable metadata for a tool run from its name and
+ * structured inputs. These keys are additive — raw inputs are left untouched
+ * for debugging and backwards compatibility.
+ */
+
+export interface ToolSemanticMetadata {
+  ls_event_kind?: "skill_load" | "skill_file_access" | "skill_file_mutation";
+  ls_resource_kind?: "skill" | "skill_file" | "file";
+  ls_file_operation?: "read" | "write" | "edit";
+  ls_skill_name?: string;
+  ls_skill_detection?: "explicit" | "inferred";
+}
+
+const FILE_OPERATION: Record<string, "read" | "write" | "edit"> = {
+  Read: "read",
+  Write: "write",
+  Edit: "edit",
+  NotebookEdit: "edit",
+};
+
+function getFilePath(input: Record<string, unknown>): string | undefined {
+  for (const key of ["file_path", "notebook_path"]) {
+    const value = input[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+interface SkillPathMatch {
+  skillName: string;
+  relativeSegments: string[];
+}
+
+// Match `.../skills/<skill>/...` by path segments, so arbitrary paths merely
+// containing the word "skill" are not misclassified.
+function matchSkillPath(path: string): SkillPathMatch | undefined {
+  const segments = path.split("/").filter((segment) => segment.length > 0);
+  const idx = segments.indexOf("skills");
+  if (idx === -1) return undefined;
+
+  const skillName = segments[idx + 1];
+  const relativeSegments = segments.slice(idx + 2);
+  if (!skillName || relativeSegments.length === 0) return undefined;
+
+  return { skillName, relativeSegments };
+}
+
+export function classifyToolCall(
+  toolName: string,
+  input: Record<string, unknown> | undefined,
+): ToolSemanticMetadata {
+  const safeInput = input ?? {};
+
+  if (toolName === "Skill") {
+    const skill = safeInput.skill;
+    return {
+      ls_event_kind: "skill_load",
+      ls_resource_kind: "skill",
+      ls_skill_detection: "explicit",
+      ...(typeof skill === "string" && skill.length > 0 ? { ls_skill_name: skill } : {}),
+    };
+  }
+
+  const fileOperation = FILE_OPERATION[toolName];
+  if (!fileOperation) return {};
+
+  const path = getFilePath(safeInput);
+  if (!path) return {};
+
+  const skillPath = matchSkillPath(path);
+  if (!skillPath) {
+    return { ls_resource_kind: "file", ls_file_operation: fileOperation };
+  }
+
+  const { skillName, relativeSegments } = skillPath;
+
+  if (fileOperation === "read") {
+    const isManifest = relativeSegments.length === 1 && relativeSegments[0] === "SKILL.md";
+    if (isManifest) {
+      return {
+        ls_event_kind: "skill_load",
+        ls_resource_kind: "skill",
+        ls_file_operation: "read",
+        ls_skill_name: skillName,
+        ls_skill_detection: "inferred",
+      };
+    }
+    return {
+      ls_event_kind: "skill_file_access",
+      ls_resource_kind: "skill_file",
+      ls_file_operation: "read",
+      ls_skill_name: skillName,
+    };
+  }
+
+  return {
+    ls_event_kind: "skill_file_mutation",
+    ls_resource_kind: "skill_file",
+    ls_file_operation: fileOperation,
+    ls_skill_name: skillName,
+  };
+}


### PR DESCRIPTION
## Description
Adds a pure classifier (`classifyToolCall`) that derives normalized, queryable metadata for tool runs from the tool name and path-segment matching, spread into both tool-run creation sites (live `PostToolUse` and transcript reconstruction).

- Explicit `Skill` calls → `skill_load` + `ls_skill_name`
- `Read` of `.../skills/<skill>/SKILL.md` → inferred `skill_load`
- `Read` of other files under a skill dir → `skill_file_access`
- `Write`/`Edit` under a skill dir → `skill_file_mutation`
- General `Read`/`Write`/`Edit` → `file` + `ls_file_operation`

Uses path-segment matching (not substring) so paths like `my-skills-helper/` are not misclassified. Raw inputs are left untouched for debugging/backwards compat.

New keys: `ls_event_kind`, `ls_resource_kind`, `ls_file_operation`, `ls_skill_name`, `ls_skill_detection`. 
Lets analytics query normalized events instead of `like(inputs, '%skills%')`.

## Self-Hosted Release Note
none 

## Test Plan
- [x] Unit tests for `classifyToolCall` covering each branch + segment-vs-substring edge case
- [x] Full suite green (134 tests), lint clean