### PR TITLE
feat(claude-code): standardized trace metadata [LSEN-306]

### DIFF
--- a/bundle/post-compact.js
+++ b/bundle/post-compact.js
@@ -8003,6 +8003,51 @@ function getSessionState(state, sessionId) {
 }
 var SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 
+// dist/metadata.js
+var LS_AGENT_KIND = "coding_agent";
+var LS_INTEGRATION = "claude-code";
+var LS_AGENT_RUNTIME = "Claude Code";
+var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
+function codingAgentMetadata(opts) {
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, legacyRole, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const meta = {
+    // Identity & grouping — always present.
+    ls_agent_kind: LS_AGENT_KIND,
+    ls_integration: LS_INTEGRATION,
+    ls_agent_runtime: LS_AGENT_RUNTIME,
+    ls_trace_schema_version: LS_TRACE_SCHEMA_VERSION,
+    thread_id: sessionId
+  };
+  if (turnId)
+    meta.turn_id = turnId;
+  if (typeof turnNumber === "number")
+    meta.turn_number = turnNumber;
+  if (runtimeVersion)
+    meta.ls_agent_runtime_version = runtimeVersion;
+  if (approvalPolicy)
+    meta.approval_policy = approvalPolicy;
+  if (legacyRole)
+    meta.ls_agent_type = legacyRole;
+  if (subagentId) {
+    meta.ls_subagent_id = subagentId;
+    meta.agent_id = subagentId;
+  }
+  if (subagentType) {
+    meta.ls_subagent_type = subagentType;
+    meta.agent_type = subagentType;
+  }
+  if (toolName) {
+    meta.tool_name = toolName;
+    if (runName && toolName !== runName)
+      meta.ls_tool_name = toolName;
+  }
+  return {
+    ...meta,
+    ...runSpecific,
+    ...base
+  };
+}
+
 // dist/langsmith.js
 var client = void 0;
 var replicas = void 0;
@@ -8027,6 +8072,13 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
+var LS_INTEGRATION_VERSION = true ? "0.1.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var PROVIDER_HOSTS = {
+  github: "github.com",
+  gitlab: "gitlab.com",
+  bitbucket: "bitbucket.org",
+  devAzure: "dev.azure.com"
+};
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -8087,6 +8139,26 @@ function getRepoName(cwd) {
   }
   return void 0;
 }
+function getGitInfo(cwd) {
+  const result = {};
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5e3
+    }).trim();
+    if (branch && branch !== "HEAD")
+      result.branch = branch;
+  } catch {
+  }
+  try {
+    const commit = execSync("git rev-parse HEAD", { cwd, encoding: "utf-8", timeout: 5e3 }).trim();
+    if (commit)
+      result.commit = commit;
+  } catch {
+  }
+  return result;
+}
 function loadConfig(options) {
   const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
@@ -8123,15 +8195,34 @@ function loadConfig(options) {
   const localUsername = readLocalUsername();
   const identityMetadata = { local_username: localUsername };
   if (anthropicUserId) {
+    identityMetadata.user_id = anthropicUserId;
     identityMetadata.anthropic_user_id = anthropicUserId;
+  }
+  const contractMetadata = {
+    ls_agent_kind: "coding_agent",
+    ls_integration: "claude-code",
+    ls_agent_runtime: "Claude Code",
+    ls_trace_schema_version: "coding-agent-v1",
+    cwd
+  };
+  if (LS_INTEGRATION_VERSION) {
+    contractMetadata.ls_integration_version = LS_INTEGRATION_VERSION;
   }
   const repoMetadata = {};
   const repoName = getRepoName(cwd);
   if (repoName != null) {
     repoMetadata.repository_name = repoName.name;
     repoMetadata.repository_provider = repoName.provider;
+    const host = PROVIDER_HOSTS[repoName.provider];
+    if (host)
+      repoMetadata.repository_url = `https://${host}/${repoName.name}`;
   }
-  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
+  const gitInfo = getGitInfo(cwd);
+  if (gitInfo.branch)
+    repoMetadata.git_branch = gitInfo.branch;
+  if (gitInfo.commit)
+    repoMetadata.git_commit_sha = gitInfo.commit;
+  customMetadata = { ...contractMetadata, ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,
@@ -8145,8 +8236,8 @@ function loadConfig(options) {
 }
 
 // dist/utils/hook-init.js
-function initHook() {
-  const config = loadConfig();
+function initHook(cwd) {
+  const config = loadConfig({ cwd });
   initLogger(config.debug);
   if (process.env.TRACE_TO_LANGSMITH?.toLowerCase() !== "true") {
     return null;
@@ -8178,7 +8269,7 @@ function readStdin() {
 // dist/hooks/post-compact.js
 async function main() {
   const input = await readStdin();
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config)
     return;
   debug(`PostCompact hook started, session=${input.session_id}, trigger=${input.trigger}`);
@@ -8208,12 +8299,13 @@ async function main() {
       dotted_order: dottedOrder,
       ...parentRunId ? { parent_run_id: parentRunId } : {},
       extra: {
-        metadata: {
-          thread_id: input.session_id,
-          ls_integration: "claude-code",
-          trigger: input.trigger,
-          ...config.customMetadata
-        }
+        metadata: codingAgentMetadata({
+          sessionId: input.session_id,
+          base: config.customMetadata,
+          turnNumber: sessionState.current_turn_number,
+          runtimeVersion: sessionState.runtime_version,
+          runSpecific: { trigger: input.trigger }
+        })
       }
     });
     await runTree.postRun();

--- a/bundle/post-compact.js
+++ b/bundle/post-compact.js
@@ -7938,7 +7938,7 @@ function debug(message) {
 }
 
 // dist/transcript.js
-import { readFileSync as readFileSync3, statSync as statSync2, openSync, readSync, closeSync } from "node:fs";
+import { readFileSync as readFileSync3, statSync as statSync2, fstatSync, openSync, readSync, closeSync } from "node:fs";
 var MAX_FULL_READ_BYTES = 50 * 1024 * 1024;
 
 // dist/state.js

--- a/bundle/post-tool-use.js
+++ b/bundle/post-tool-use.js
@@ -7938,7 +7938,7 @@ function debug(message) {
 }
 
 // dist/transcript.js
-import { readFileSync as readFileSync3, statSync as statSync2, openSync, readSync, closeSync } from "node:fs";
+import { readFileSync as readFileSync3, statSync as statSync2, fstatSync, openSync, readSync, closeSync } from "node:fs";
 var MAX_FULL_READ_BYTES = 50 * 1024 * 1024;
 
 // dist/state.js

--- a/bundle/post-tool-use.js
+++ b/bundle/post-tool-use.js
@@ -8003,6 +8003,51 @@ function getSessionState(state, sessionId) {
 }
 var SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 
+// dist/metadata.js
+var LS_AGENT_KIND = "coding_agent";
+var LS_INTEGRATION = "claude-code";
+var LS_AGENT_RUNTIME = "Claude Code";
+var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
+function codingAgentMetadata(opts) {
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, legacyRole, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const meta = {
+    // Identity & grouping — always present.
+    ls_agent_kind: LS_AGENT_KIND,
+    ls_integration: LS_INTEGRATION,
+    ls_agent_runtime: LS_AGENT_RUNTIME,
+    ls_trace_schema_version: LS_TRACE_SCHEMA_VERSION,
+    thread_id: sessionId
+  };
+  if (turnId)
+    meta.turn_id = turnId;
+  if (typeof turnNumber === "number")
+    meta.turn_number = turnNumber;
+  if (runtimeVersion)
+    meta.ls_agent_runtime_version = runtimeVersion;
+  if (approvalPolicy)
+    meta.approval_policy = approvalPolicy;
+  if (legacyRole)
+    meta.ls_agent_type = legacyRole;
+  if (subagentId) {
+    meta.ls_subagent_id = subagentId;
+    meta.agent_id = subagentId;
+  }
+  if (subagentType) {
+    meta.ls_subagent_type = subagentType;
+    meta.agent_type = subagentType;
+  }
+  if (toolName) {
+    meta.tool_name = toolName;
+    if (runName && toolName !== runName)
+      meta.ls_tool_name = toolName;
+  }
+  return {
+    ...meta,
+    ...runSpecific,
+    ...base
+  };
+}
+
 // dist/langsmith.js
 var client = void 0;
 var replicas = void 0;
@@ -8035,6 +8080,13 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
+var LS_INTEGRATION_VERSION = true ? "0.1.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var PROVIDER_HOSTS = {
+  github: "github.com",
+  gitlab: "gitlab.com",
+  bitbucket: "bitbucket.org",
+  devAzure: "dev.azure.com"
+};
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -8095,6 +8147,26 @@ function getRepoName(cwd) {
   }
   return void 0;
 }
+function getGitInfo(cwd) {
+  const result = {};
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5e3
+    }).trim();
+    if (branch && branch !== "HEAD")
+      result.branch = branch;
+  } catch {
+  }
+  try {
+    const commit = execSync("git rev-parse HEAD", { cwd, encoding: "utf-8", timeout: 5e3 }).trim();
+    if (commit)
+      result.commit = commit;
+  } catch {
+  }
+  return result;
+}
 function loadConfig(options) {
   const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
@@ -8131,15 +8203,34 @@ function loadConfig(options) {
   const localUsername = readLocalUsername();
   const identityMetadata = { local_username: localUsername };
   if (anthropicUserId) {
+    identityMetadata.user_id = anthropicUserId;
     identityMetadata.anthropic_user_id = anthropicUserId;
+  }
+  const contractMetadata = {
+    ls_agent_kind: "coding_agent",
+    ls_integration: "claude-code",
+    ls_agent_runtime: "Claude Code",
+    ls_trace_schema_version: "coding-agent-v1",
+    cwd
+  };
+  if (LS_INTEGRATION_VERSION) {
+    contractMetadata.ls_integration_version = LS_INTEGRATION_VERSION;
   }
   const repoMetadata = {};
   const repoName = getRepoName(cwd);
   if (repoName != null) {
     repoMetadata.repository_name = repoName.name;
     repoMetadata.repository_provider = repoName.provider;
+    const host = PROVIDER_HOSTS[repoName.provider];
+    if (host)
+      repoMetadata.repository_url = `https://${host}/${repoName.name}`;
   }
-  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
+  const gitInfo = getGitInfo(cwd);
+  if (gitInfo.branch)
+    repoMetadata.git_branch = gitInfo.branch;
+  if (gitInfo.commit)
+    repoMetadata.git_commit_sha = gitInfo.commit;
+  customMetadata = { ...contractMetadata, ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,
@@ -8153,8 +8244,8 @@ function loadConfig(options) {
 }
 
 // dist/utils/hook-init.js
-function initHook() {
-  const config = loadConfig();
+function initHook(cwd) {
+  const config = loadConfig({ cwd });
   initLogger(config.debug);
   if (process.env.TRACE_TO_LANGSMITH?.toLowerCase() !== "true") {
     return null;
@@ -8186,7 +8277,7 @@ function readStdin() {
 // dist/hooks/post-tool-use.js
 async function main() {
   const input = await readStdin();
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config)
     return;
   if (input.agent_id || input.agent_type) {
@@ -8229,12 +8320,16 @@ async function main() {
       trace_id: traceId,
       dotted_order: toolDottedOrder,
       extra: {
-        metadata: {
-          thread_id: input.session_id,
-          ls_integration: "claude-code",
-          tool_name: input.tool_name,
-          ...config.customMetadata
-        }
+        metadata: codingAgentMetadata({
+          sessionId: input.session_id,
+          base: config.customMetadata,
+          // turn_id (promptId) isn't in the PostToolUse payload; turn_number is
+          // sufficient (the contract needs at least one of the two).
+          turnNumber: sessionState.current_turn_number,
+          runtimeVersion: sessionState.runtime_version,
+          toolName: input.tool_name,
+          runName: input.tool_name
+        })
       }
     });
     await runTree.postRun();

--- a/bundle/pre-compact.js
+++ b/bundle/pre-compact.js
@@ -104,6 +104,13 @@ import { readFileSync as readFileSync2 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
+var LS_INTEGRATION_VERSION = true ? "0.1.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var PROVIDER_HOSTS = {
+  github: "github.com",
+  gitlab: "gitlab.com",
+  bitbucket: "bitbucket.org",
+  devAzure: "dev.azure.com"
+};
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -164,6 +171,26 @@ function getRepoName(cwd) {
   }
   return void 0;
 }
+function getGitInfo(cwd) {
+  const result = {};
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5e3
+    }).trim();
+    if (branch && branch !== "HEAD")
+      result.branch = branch;
+  } catch {
+  }
+  try {
+    const commit = execSync("git rev-parse HEAD", { cwd, encoding: "utf-8", timeout: 5e3 }).trim();
+    if (commit)
+      result.commit = commit;
+  } catch {
+  }
+  return result;
+}
 function loadConfig(options) {
   const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
@@ -200,15 +227,34 @@ function loadConfig(options) {
   const localUsername = readLocalUsername();
   const identityMetadata = { local_username: localUsername };
   if (anthropicUserId) {
+    identityMetadata.user_id = anthropicUserId;
     identityMetadata.anthropic_user_id = anthropicUserId;
+  }
+  const contractMetadata = {
+    ls_agent_kind: "coding_agent",
+    ls_integration: "claude-code",
+    ls_agent_runtime: "Claude Code",
+    ls_trace_schema_version: "coding-agent-v1",
+    cwd
+  };
+  if (LS_INTEGRATION_VERSION) {
+    contractMetadata.ls_integration_version = LS_INTEGRATION_VERSION;
   }
   const repoMetadata = {};
   const repoName = getRepoName(cwd);
   if (repoName != null) {
     repoMetadata.repository_name = repoName.name;
     repoMetadata.repository_provider = repoName.provider;
+    const host = PROVIDER_HOSTS[repoName.provider];
+    if (host)
+      repoMetadata.repository_url = `https://${host}/${repoName.name}`;
   }
-  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
+  const gitInfo = getGitInfo(cwd);
+  if (gitInfo.branch)
+    repoMetadata.git_branch = gitInfo.branch;
+  if (gitInfo.commit)
+    repoMetadata.git_commit_sha = gitInfo.commit;
+  customMetadata = { ...contractMetadata, ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,
@@ -222,8 +268,8 @@ function loadConfig(options) {
 }
 
 // dist/utils/hook-init.js
-function initHook() {
-  const config = loadConfig();
+function initHook(cwd) {
+  const config = loadConfig({ cwd });
   initLogger(config.debug);
   if (process.env.TRACE_TO_LANGSMITH?.toLowerCase() !== "true") {
     return null;
@@ -255,7 +301,7 @@ function readStdin() {
 // dist/hooks/pre-compact.js
 async function main() {
   const input = await readStdin();
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config)
     return;
   debug(`PreCompact hook started, session=${input.session_id}, trigger=${input.trigger}`);

--- a/bundle/pre-tool-use.js
+++ b/bundle/pre-tool-use.js
@@ -104,6 +104,13 @@ import { readFileSync as readFileSync2 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
+var LS_INTEGRATION_VERSION = true ? "0.1.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var PROVIDER_HOSTS = {
+  github: "github.com",
+  gitlab: "gitlab.com",
+  bitbucket: "bitbucket.org",
+  devAzure: "dev.azure.com"
+};
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -164,6 +171,26 @@ function getRepoName(cwd) {
   }
   return void 0;
 }
+function getGitInfo(cwd) {
+  const result = {};
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5e3
+    }).trim();
+    if (branch && branch !== "HEAD")
+      result.branch = branch;
+  } catch {
+  }
+  try {
+    const commit = execSync("git rev-parse HEAD", { cwd, encoding: "utf-8", timeout: 5e3 }).trim();
+    if (commit)
+      result.commit = commit;
+  } catch {
+  }
+  return result;
+}
 function loadConfig(options) {
   const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
@@ -200,15 +227,34 @@ function loadConfig(options) {
   const localUsername = readLocalUsername();
   const identityMetadata = { local_username: localUsername };
   if (anthropicUserId) {
+    identityMetadata.user_id = anthropicUserId;
     identityMetadata.anthropic_user_id = anthropicUserId;
+  }
+  const contractMetadata = {
+    ls_agent_kind: "coding_agent",
+    ls_integration: "claude-code",
+    ls_agent_runtime: "Claude Code",
+    ls_trace_schema_version: "coding-agent-v1",
+    cwd
+  };
+  if (LS_INTEGRATION_VERSION) {
+    contractMetadata.ls_integration_version = LS_INTEGRATION_VERSION;
   }
   const repoMetadata = {};
   const repoName = getRepoName(cwd);
   if (repoName != null) {
     repoMetadata.repository_name = repoName.name;
     repoMetadata.repository_provider = repoName.provider;
+    const host = PROVIDER_HOSTS[repoName.provider];
+    if (host)
+      repoMetadata.repository_url = `https://${host}/${repoName.name}`;
   }
-  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
+  const gitInfo = getGitInfo(cwd);
+  if (gitInfo.branch)
+    repoMetadata.git_branch = gitInfo.branch;
+  if (gitInfo.commit)
+    repoMetadata.git_commit_sha = gitInfo.commit;
+  customMetadata = { ...contractMetadata, ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,
@@ -222,8 +268,8 @@ function loadConfig(options) {
 }
 
 // dist/utils/hook-init.js
-function initHook() {
-  const config = loadConfig();
+function initHook(cwd) {
+  const config = loadConfig({ cwd });
   initLogger(config.debug);
   if (process.env.TRACE_TO_LANGSMITH?.toLowerCase() !== "true") {
     return null;

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -7944,7 +7944,7 @@ function uuid7() {
 var __version__ = "0.5.19";
 
 // dist/transcript.js
-import { readFileSync as readFileSync3, statSync as statSync2, openSync, readSync, closeSync } from "node:fs";
+import { readFileSync as readFileSync3, statSync as statSync2, fstatSync, openSync, readSync, closeSync } from "node:fs";
 var MAX_FULL_READ_BYTES = 50 * 1024 * 1024;
 function readTranscript(filePath, afterLine = -1) {
   let size;
@@ -8017,14 +8017,14 @@ function readTranscript(filePath, afterLine = -1) {
 function readRuntimeVersion(filePath) {
   let fd;
   try {
-    const size = statSync2(filePath).size;
+    fd = openSync(filePath, "r");
+    const size = fstatSync(fd).size;
     if (size === 0)
       return void 0;
     const window2 = 64 * 1024;
     const start = Math.max(0, size - window2);
     const len = size - start;
     const buf = Buffer.alloc(len);
-    fd = openSync(filePath, "r");
     readSync(fd, buf, 0, len, start);
     const text = buf.toString("utf-8");
     const lines = text.split("\n").filter((l) => l.trim() !== "");

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -8014,6 +8014,36 @@ function readTranscript(filePath, afterLine = -1) {
     closeSync(fd);
   }
 }
+function readRuntimeVersion(filePath) {
+  let fd;
+  try {
+    const size = statSync2(filePath).size;
+    if (size === 0)
+      return void 0;
+    const window2 = 64 * 1024;
+    const start = Math.max(0, size - window2);
+    const len = size - start;
+    const buf = Buffer.alloc(len);
+    fd = openSync(filePath, "r");
+    readSync(fd, buf, 0, len, start);
+    const text = buf.toString("utf-8");
+    const lines = text.split("\n").filter((l) => l.trim() !== "");
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const parsed = JSON.parse(lines[i]);
+        if (typeof parsed.version === "string" && parsed.version.length > 0) {
+          return parsed.version;
+        }
+      } catch {
+      }
+    }
+  } catch {
+  } finally {
+    if (fd !== void 0)
+      closeSync(fd);
+  }
+  return void 0;
+}
 function isHumanMessage(msg) {
   if (msg.type !== "user")
     return false;
@@ -8130,7 +8160,8 @@ function groupIntoTurns(messages) {
       userContent: currentUser.message.content,
       userTimestamp: currentUser.timestamp,
       llmCalls,
-      isComplete
+      isComplete,
+      promptId: currentUser.promptId
     });
   }
   for (const msg of messages) {
@@ -8229,6 +8260,51 @@ var SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 var USER_PROMPT_TURN_NAME = "Claude Code Turn";
 var ASSISTANT_RUN_NAME = "Claude";
 
+// dist/metadata.js
+var LS_AGENT_KIND = "coding_agent";
+var LS_INTEGRATION = "claude-code";
+var LS_AGENT_RUNTIME = "Claude Code";
+var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
+function codingAgentMetadata(opts) {
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, legacyRole, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const meta = {
+    // Identity & grouping — always present.
+    ls_agent_kind: LS_AGENT_KIND,
+    ls_integration: LS_INTEGRATION,
+    ls_agent_runtime: LS_AGENT_RUNTIME,
+    ls_trace_schema_version: LS_TRACE_SCHEMA_VERSION,
+    thread_id: sessionId
+  };
+  if (turnId)
+    meta.turn_id = turnId;
+  if (typeof turnNumber === "number")
+    meta.turn_number = turnNumber;
+  if (runtimeVersion)
+    meta.ls_agent_runtime_version = runtimeVersion;
+  if (approvalPolicy)
+    meta.approval_policy = approvalPolicy;
+  if (legacyRole)
+    meta.ls_agent_type = legacyRole;
+  if (subagentId) {
+    meta.ls_subagent_id = subagentId;
+    meta.agent_id = subagentId;
+  }
+  if (subagentType) {
+    meta.ls_subagent_type = subagentType;
+    meta.agent_type = subagentType;
+  }
+  if (toolName) {
+    meta.tool_name = toolName;
+    if (runName && toolName !== runName)
+      meta.ls_tool_name = toolName;
+  }
+  return {
+    ...meta,
+    ...runSpecific,
+    ...base
+  };
+}
+
 // dist/langsmith.js
 var client = void 0;
 var replicas = void 0;
@@ -8287,7 +8363,8 @@ function buildUsageMetadata(usage) {
   };
 }
 async function traceTurn(options) {
-  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata } = options;
+  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata, runtimeVersion, approvalPolicy } = options;
+  const turnId = turn.promptId;
   let traceId = providedTraceId;
   let parentDottedOrder = providedParentDottedOrder;
   if (!client && !replicas) {
@@ -8319,7 +8396,18 @@ async function traceTurn(options) {
       start_time: turn.userTimestamp,
       trace_id: traceId,
       dotted_order: parentDottedOrder,
-      ...customMetadata ? { extra: { metadata: { ...customMetadata } } } : {}
+      extra: {
+        metadata: codingAgentMetadata({
+          sessionId,
+          base: customMetadata,
+          turnId,
+          turnNumber: turnNum,
+          runtimeVersion,
+          approvalPolicy,
+          legacyRole: "root"
+          // DEPRECATED compat alias ls_agent_type="root".
+        })
+      }
     });
     await runTree.postRun();
   }
@@ -8379,7 +8467,15 @@ async function traceTurn(options) {
         trace_id: traceId,
         dotted_order: toolDottedOrder,
         extra: {
-          metadata: { thread_id: sessionId, ls_integration: "claude-code", ...customMetadata }
+          metadata: codingAgentMetadata({
+            sessionId,
+            base: customMetadata,
+            turnId,
+            turnNumber: turnNum,
+            runtimeVersion,
+            toolName: toolCall.tool_use.name,
+            runName: toolCall.tool_use.name
+          })
         }
       });
       await runTree2.postRun();
@@ -8409,18 +8505,22 @@ async function traceTurn(options) {
         messages: [{ role: "assistant", content: assistantContent }]
       },
       extra: {
-        metadata: {
-          thread_id: sessionId,
-          ls_integration: "claude-code",
-          ls_provider: "anthropic",
-          ls_model_name: llmCall.model,
-          ls_invocation_params: {
-            model: llmCall.model
-          },
-          usage_metadata: buildUsageMetadata(llmCall.usage),
-          ...llmCall.synthetic ? { synthetic: true } : {},
-          ...customMetadata
-        }
+        metadata: codingAgentMetadata({
+          sessionId,
+          base: customMetadata,
+          turnId,
+          turnNumber: turnNum,
+          runtimeVersion,
+          runSpecific: {
+            ls_provider: "anthropic",
+            ls_model_name: llmCall.model,
+            ls_invocation_params: {
+              model: llmCall.model
+            },
+            usage_metadata: buildUsageMetadata(llmCall.usage),
+            ...llmCall.synthetic ? { synthetic: true } : {}
+          }
+        })
       }
     });
     await runTree.patchRun({ excludeInputs: true });
@@ -8451,12 +8551,16 @@ async function traceTurn(options) {
       outputs: { messages: turnOutputs },
       error: error2,
       extra: {
-        metadata: {
-          thread_id: sessionId,
-          ls_integration: "claude-code",
-          turn_number: turnNum,
-          ...customMetadata
-        }
+        metadata: codingAgentMetadata({
+          sessionId,
+          base: customMetadata,
+          turnId,
+          turnNumber: turnNum,
+          runtimeVersion,
+          approvalPolicy,
+          legacyRole: "root"
+          // DEPRECATED compat alias ls_agent_type="root".
+        })
       }
     });
     await runTree.patchRun({ excludeInputs: true });
@@ -8466,18 +8570,21 @@ async function traceTurn(options) {
   return taskRunMap;
 }
 async function closeInterruptedTurn(options) {
-  const { sessionId, sessionState, transcriptPath, project, stateFilePath, customMetadata } = options;
+  const { sessionId, sessionState, transcriptPath, project, stateFilePath, customMetadata, runtimeVersion, approvalPolicy } = options;
   if (!client && !replicas)
     throw new Error("LangSmith client not initialized \u2014 call initTracing() first");
   let lastLine = sessionState.last_line;
   let turnsTraced = 0;
   let taskRunMap = sessionState.task_run_map ?? {};
+  let turnId;
+  const turnNumber = sessionState.current_turn_number;
   if (transcriptPath) {
     try {
       const { messages, lastLine: newLastLine } = readTranscript(transcriptPath, sessionState.last_line);
       if (messages.length > 0) {
         const turns = groupIntoTurns(messages);
         if (turns.length > 0) {
+          turnId = turns[turns.length - 1].promptId;
           await traceTurn({
             turn: turns[turns.length - 1],
             sessionId,
@@ -8487,7 +8594,10 @@ async function closeInterruptedTurn(options) {
             existingTaskRunMap: taskRunMap,
             tracedToolUseIds: new Set(sessionState.traced_tool_use_ids ?? []),
             traceId: sessionState.current_trace_id,
-            parentDottedOrder: sessionState.current_dotted_order
+            parentDottedOrder: sessionState.current_dotted_order,
+            customMetadata,
+            runtimeVersion,
+            approvalPolicy
           });
           lastLine = newLastLine;
           turnsTraced = 1;
@@ -8508,7 +8618,10 @@ async function closeInterruptedTurn(options) {
         taskRunMap,
         parentTraceId: sessionState.current_trace_id,
         project,
-        customMetadata
+        customMetadata,
+        runtimeVersion,
+        turnId,
+        turnNumber
       });
     } catch (err) {
       error(`Failed to trace pending subagents on interrupt: ${err}`);
@@ -8528,12 +8641,15 @@ async function closeInterruptedTurn(options) {
     end_time: (/* @__PURE__ */ new Date()).toISOString(),
     error: "User interrupt",
     extra: {
-      metadata: {
-        thread_id: sessionId,
-        ls_integration: "claude-code",
-        turn_number: sessionState.current_turn_number,
-        ...customMetadata
-      }
+      metadata: codingAgentMetadata({
+        sessionId,
+        base: customMetadata,
+        turnNumber: sessionState.current_turn_number,
+        runtimeVersion,
+        approvalPolicy,
+        legacyRole: "root"
+        // DEPRECATED compat alias ls_agent_type="root".
+      })
     }
   });
   await runTree.patchRun({ excludeInputs: true });
@@ -8541,7 +8657,7 @@ async function closeInterruptedTurn(options) {
   return { lastLine, turnsTraced };
 }
 async function tracePendingSubagents(options) {
-  const { sessionId, pendingSubagents, taskRunMap, parentTraceId, project, customMetadata } = options;
+  const { sessionId, pendingSubagents, taskRunMap, parentTraceId, project, customMetadata, runtimeVersion, turnId, turnNumber } = options;
   if (!client && !replicas) {
     throw new Error("LangSmith client not initialized \u2014 call initTracing() first");
   }
@@ -8585,14 +8701,22 @@ async function tracePendingSubagents(options) {
           trace_id: deferred.trace_id,
           dotted_order: agentToolDottedOrder,
           extra: {
-            metadata: {
-              thread_id: sessionId,
-              ls_integration: "claude-code",
-              tool_name: "Agent",
-              agent_type: toolName,
-              agent_id: subagent.agent_id,
-              ...customMetadata
-            }
+            metadata: codingAgentMetadata({
+              sessionId,
+              base: customMetadata,
+              runtimeVersion,
+              turnId,
+              turnNumber,
+              // run_type "tool" (run name "Agent", native tool "Task").
+              toolName: "Task",
+              runName: "Agent",
+              runSpecific: {
+                agent_type: toolName,
+                // DEPRECATED compat alias.
+                agent_id: subagent.agent_id
+                // DEPRECATED compat alias.
+              }
+            })
           }
         });
         await runTree2.postRun();
@@ -8614,14 +8738,19 @@ async function tracePendingSubagents(options) {
         trace_id: parentTraceId,
         dotted_order: subagentChainDottedOrder,
         extra: {
-          metadata: {
-            thread_id: sessionId,
-            ls_integration: "claude-code",
-            ls_agent_type: "subagent",
-            agent_type: toolName,
-            agent_id: subagent.agent_id,
-            ...customMetadata
-          }
+          metadata: codingAgentMetadata({
+            sessionId,
+            base: customMetadata,
+            runtimeVersion,
+            turnId,
+            turnNumber,
+            legacyRole: "subagent",
+            // DEPRECATED compat alias.
+            subagentId: subagent.agent_id,
+            // → ls_subagent_id (+ agent_id alias).
+            subagentType: toolName
+            // → ls_subagent_type (+ agent_type alias).
+          })
         }
       });
       await runTree.postRun();
@@ -8635,7 +8764,8 @@ async function tracePendingSubagents(options) {
           existingTaskRunMap: void 0,
           traceId: parentTraceId,
           parentDottedOrder: subagentChainDottedOrder,
-          customMetadata
+          customMetadata,
+          runtimeVersion
         });
       }
       log(`Traced subagent ${toolName} (${subagent.agent_id}): ${subagentTurns.length} turn(s)`);
@@ -8650,6 +8780,13 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
+var LS_INTEGRATION_VERSION = true ? "0.1.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var PROVIDER_HOSTS = {
+  github: "github.com",
+  gitlab: "gitlab.com",
+  bitbucket: "bitbucket.org",
+  devAzure: "dev.azure.com"
+};
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -8710,6 +8847,26 @@ function getRepoName(cwd) {
   }
   return void 0;
 }
+function getGitInfo(cwd) {
+  const result = {};
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5e3
+    }).trim();
+    if (branch && branch !== "HEAD")
+      result.branch = branch;
+  } catch {
+  }
+  try {
+    const commit = execSync("git rev-parse HEAD", { cwd, encoding: "utf-8", timeout: 5e3 }).trim();
+    if (commit)
+      result.commit = commit;
+  } catch {
+  }
+  return result;
+}
 function loadConfig(options) {
   const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
@@ -8746,15 +8903,34 @@ function loadConfig(options) {
   const localUsername = readLocalUsername();
   const identityMetadata = { local_username: localUsername };
   if (anthropicUserId) {
+    identityMetadata.user_id = anthropicUserId;
     identityMetadata.anthropic_user_id = anthropicUserId;
+  }
+  const contractMetadata = {
+    ls_agent_kind: "coding_agent",
+    ls_integration: "claude-code",
+    ls_agent_runtime: "Claude Code",
+    ls_trace_schema_version: "coding-agent-v1",
+    cwd
+  };
+  if (LS_INTEGRATION_VERSION) {
+    contractMetadata.ls_integration_version = LS_INTEGRATION_VERSION;
   }
   const repoMetadata = {};
   const repoName = getRepoName(cwd);
   if (repoName != null) {
     repoMetadata.repository_name = repoName.name;
     repoMetadata.repository_provider = repoName.provider;
+    const host = PROVIDER_HOSTS[repoName.provider];
+    if (host)
+      repoMetadata.repository_url = `https://${host}/${repoName.name}`;
   }
-  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
+  const gitInfo = getGitInfo(cwd);
+  if (gitInfo.branch)
+    repoMetadata.git_branch = gitInfo.branch;
+  if (gitInfo.commit)
+    repoMetadata.git_commit_sha = gitInfo.commit;
+  customMetadata = { ...contractMetadata, ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,
@@ -8768,8 +8944,8 @@ function loadConfig(options) {
 }
 
 // dist/utils/hook-init.js
-function initHook() {
-  const config = loadConfig();
+function initHook(cwd) {
+  const config = loadConfig({ cwd });
   initLogger(config.debug);
   if (process.env.TRACE_TO_LANGSMITH?.toLowerCase() !== "true") {
     return null;
@@ -8804,7 +8980,7 @@ function readStdin() {
 // dist/hooks/session-end.js
 async function main() {
   const input = await readStdin();
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config)
     return;
   debug(`SessionEnd hook: session=${input.session_id}, reason=${input.reason}`);
@@ -8816,14 +8992,18 @@ async function main() {
   }
   initTracing(config.apiKey, config.apiBaseUrl, config.replicas);
   debug(`Closing interrupted turn run ${sessionState.current_turn_run_id} on session end`);
+  const expandedTranscript = expandHome(input.transcript_path);
+  const runtimeVersion = sessionState.runtime_version ?? (expandedTranscript ? readRuntimeVersion(expandedTranscript) : void 0);
   try {
     const { lastLine, turnsTraced } = await closeInterruptedTurn({
       sessionId: input.session_id,
       sessionState,
-      transcriptPath: expandHome(input.transcript_path),
+      transcriptPath: expandedTranscript,
       project: config.project,
       stateFilePath: config.stateFilePath,
-      customMetadata: config.customMetadata
+      customMetadata: config.customMetadata,
+      runtimeVersion,
+      approvalPolicy: sessionState.approval_policy
     });
     await atomicUpdateState(config.stateFilePath, (s) => {
       const ss = getSessionState(s, input.session_id);

--- a/bundle/stop-failure.js
+++ b/bundle/stop-failure.js
@@ -8001,6 +8001,51 @@ var SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 // dist/constants.js
 var USER_PROMPT_TURN_NAME = "Claude Code Turn";
 
+// dist/metadata.js
+var LS_AGENT_KIND = "coding_agent";
+var LS_INTEGRATION = "claude-code";
+var LS_AGENT_RUNTIME = "Claude Code";
+var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
+function codingAgentMetadata(opts) {
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, legacyRole, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const meta = {
+    // Identity & grouping — always present.
+    ls_agent_kind: LS_AGENT_KIND,
+    ls_integration: LS_INTEGRATION,
+    ls_agent_runtime: LS_AGENT_RUNTIME,
+    ls_trace_schema_version: LS_TRACE_SCHEMA_VERSION,
+    thread_id: sessionId
+  };
+  if (turnId)
+    meta.turn_id = turnId;
+  if (typeof turnNumber === "number")
+    meta.turn_number = turnNumber;
+  if (runtimeVersion)
+    meta.ls_agent_runtime_version = runtimeVersion;
+  if (approvalPolicy)
+    meta.approval_policy = approvalPolicy;
+  if (legacyRole)
+    meta.ls_agent_type = legacyRole;
+  if (subagentId) {
+    meta.ls_subagent_id = subagentId;
+    meta.agent_id = subagentId;
+  }
+  if (subagentType) {
+    meta.ls_subagent_type = subagentType;
+    meta.agent_type = subagentType;
+  }
+  if (toolName) {
+    meta.tool_name = toolName;
+    if (runName && toolName !== runName)
+      meta.ls_tool_name = toolName;
+  }
+  return {
+    ...meta,
+    ...runSpecific,
+    ...base
+  };
+}
+
 // dist/langsmith.js
 var client = void 0;
 var replicas = void 0;
@@ -8027,6 +8072,13 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
+var LS_INTEGRATION_VERSION = true ? "0.1.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var PROVIDER_HOSTS = {
+  github: "github.com",
+  gitlab: "gitlab.com",
+  bitbucket: "bitbucket.org",
+  devAzure: "dev.azure.com"
+};
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -8087,6 +8139,26 @@ function getRepoName(cwd) {
   }
   return void 0;
 }
+function getGitInfo(cwd) {
+  const result = {};
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5e3
+    }).trim();
+    if (branch && branch !== "HEAD")
+      result.branch = branch;
+  } catch {
+  }
+  try {
+    const commit = execSync("git rev-parse HEAD", { cwd, encoding: "utf-8", timeout: 5e3 }).trim();
+    if (commit)
+      result.commit = commit;
+  } catch {
+  }
+  return result;
+}
 function loadConfig(options) {
   const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
@@ -8123,15 +8195,34 @@ function loadConfig(options) {
   const localUsername = readLocalUsername();
   const identityMetadata = { local_username: localUsername };
   if (anthropicUserId) {
+    identityMetadata.user_id = anthropicUserId;
     identityMetadata.anthropic_user_id = anthropicUserId;
+  }
+  const contractMetadata = {
+    ls_agent_kind: "coding_agent",
+    ls_integration: "claude-code",
+    ls_agent_runtime: "Claude Code",
+    ls_trace_schema_version: "coding-agent-v1",
+    cwd
+  };
+  if (LS_INTEGRATION_VERSION) {
+    contractMetadata.ls_integration_version = LS_INTEGRATION_VERSION;
   }
   const repoMetadata = {};
   const repoName = getRepoName(cwd);
   if (repoName != null) {
     repoMetadata.repository_name = repoName.name;
     repoMetadata.repository_provider = repoName.provider;
+    const host = PROVIDER_HOSTS[repoName.provider];
+    if (host)
+      repoMetadata.repository_url = `https://${host}/${repoName.name}`;
   }
-  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
+  const gitInfo = getGitInfo(cwd);
+  if (gitInfo.branch)
+    repoMetadata.git_branch = gitInfo.branch;
+  if (gitInfo.commit)
+    repoMetadata.git_commit_sha = gitInfo.commit;
+  customMetadata = { ...contractMetadata, ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,
@@ -8145,8 +8236,8 @@ function loadConfig(options) {
 }
 
 // dist/utils/hook-init.js
-function initHook() {
-  const config = loadConfig();
+function initHook(cwd) {
+  const config = loadConfig({ cwd });
   initLogger(config.debug);
   if (process.env.TRACE_TO_LANGSMITH?.toLowerCase() !== "true") {
     return null;
@@ -8178,7 +8269,7 @@ function readStdin() {
 // dist/hooks/stop-failure.js
 async function main() {
   const input = await readStdin();
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config)
     return;
   debug(`StopFailure hook: session=${input.session_id}, error=${input.error}`);
@@ -8205,12 +8296,15 @@ async function main() {
       end_time: (/* @__PURE__ */ new Date()).toISOString(),
       error: errorMessage,
       extra: {
-        metadata: {
-          thread_id: input.session_id,
-          ls_integration: "claude-code",
-          turn_number: sessionState.current_turn_number,
-          ...config.customMetadata
-        }
+        metadata: codingAgentMetadata({
+          sessionId: input.session_id,
+          base: config.customMetadata,
+          turnNumber: sessionState.current_turn_number,
+          runtimeVersion: sessionState.runtime_version,
+          approvalPolicy: sessionState.approval_policy,
+          legacyRole: "root"
+          // DEPRECATED compat alias ls_agent_type="root".
+        })
       }
     });
     await runTree.patchRun({ excludeInputs: true });

--- a/bundle/stop-failure.js
+++ b/bundle/stop-failure.js
@@ -7933,7 +7933,7 @@ function _checkEndpointEnvUnset(parsed) {
 var __version__ = "0.5.19";
 
 // dist/transcript.js
-import { readFileSync as readFileSync3, statSync as statSync2, openSync, readSync, closeSync } from "node:fs";
+import { readFileSync as readFileSync3, statSync as statSync2, fstatSync, openSync, readSync, closeSync } from "node:fs";
 var MAX_FULL_READ_BYTES = 50 * 1024 * 1024;
 
 // dist/state.js

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -661,6 +661,36 @@ function readTranscript(filePath, afterLine = -1) {
     closeSync(fd);
   }
 }
+function readRuntimeVersion(filePath) {
+  let fd;
+  try {
+    const size = statSync(filePath).size;
+    if (size === 0)
+      return void 0;
+    const window2 = 64 * 1024;
+    const start = Math.max(0, size - window2);
+    const len = size - start;
+    const buf = Buffer.alloc(len);
+    fd = openSync(filePath, "r");
+    readSync(fd, buf, 0, len, start);
+    const text = buf.toString("utf-8");
+    const lines = text.split("\n").filter((l) => l.trim() !== "");
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const parsed = JSON.parse(lines[i]);
+        if (typeof parsed.version === "string" && parsed.version.length > 0) {
+          return parsed.version;
+        }
+      } catch {
+      }
+    }
+  } catch {
+  } finally {
+    if (fd !== void 0)
+      closeSync(fd);
+  }
+  return void 0;
+}
 function isHumanMessage(msg) {
   if (msg.type !== "user")
     return false;
@@ -777,7 +807,8 @@ function groupIntoTurns(messages) {
       userContent: currentUser.message.content,
       userTimestamp: currentUser.timestamp,
       llmCalls,
-      isComplete
+      isComplete,
+      promptId: currentUser.promptId
     });
   }
   for (const msg of messages) {
@@ -8259,6 +8290,51 @@ var __version__ = "0.5.19";
 var USER_PROMPT_TURN_NAME = "Claude Code Turn";
 var ASSISTANT_RUN_NAME = "Claude";
 
+// dist/metadata.js
+var LS_AGENT_KIND = "coding_agent";
+var LS_INTEGRATION = "claude-code";
+var LS_AGENT_RUNTIME = "Claude Code";
+var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
+function codingAgentMetadata(opts) {
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, legacyRole, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const meta = {
+    // Identity & grouping — always present.
+    ls_agent_kind: LS_AGENT_KIND,
+    ls_integration: LS_INTEGRATION,
+    ls_agent_runtime: LS_AGENT_RUNTIME,
+    ls_trace_schema_version: LS_TRACE_SCHEMA_VERSION,
+    thread_id: sessionId
+  };
+  if (turnId)
+    meta.turn_id = turnId;
+  if (typeof turnNumber === "number")
+    meta.turn_number = turnNumber;
+  if (runtimeVersion)
+    meta.ls_agent_runtime_version = runtimeVersion;
+  if (approvalPolicy)
+    meta.approval_policy = approvalPolicy;
+  if (legacyRole)
+    meta.ls_agent_type = legacyRole;
+  if (subagentId) {
+    meta.ls_subagent_id = subagentId;
+    meta.agent_id = subagentId;
+  }
+  if (subagentType) {
+    meta.ls_subagent_type = subagentType;
+    meta.agent_type = subagentType;
+  }
+  if (toolName) {
+    meta.tool_name = toolName;
+    if (runName && toolName !== runName)
+      meta.ls_tool_name = toolName;
+  }
+  return {
+    ...meta,
+    ...runSpecific,
+    ...base
+  };
+}
+
 // dist/langsmith.js
 var client = void 0;
 var replicas = void 0;
@@ -8317,7 +8393,8 @@ function buildUsageMetadata(usage) {
   };
 }
 async function traceTurn(options) {
-  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata } = options;
+  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata, runtimeVersion, approvalPolicy } = options;
+  const turnId = turn.promptId;
   let traceId = providedTraceId;
   let parentDottedOrder = providedParentDottedOrder;
   if (!client && !replicas) {
@@ -8349,7 +8426,18 @@ async function traceTurn(options) {
       start_time: turn.userTimestamp,
       trace_id: traceId,
       dotted_order: parentDottedOrder,
-      ...customMetadata ? { extra: { metadata: { ...customMetadata } } } : {}
+      extra: {
+        metadata: codingAgentMetadata({
+          sessionId,
+          base: customMetadata,
+          turnId,
+          turnNumber: turnNum,
+          runtimeVersion,
+          approvalPolicy,
+          legacyRole: "root"
+          // DEPRECATED compat alias ls_agent_type="root".
+        })
+      }
     });
     await runTree.postRun();
   }
@@ -8409,7 +8497,15 @@ async function traceTurn(options) {
         trace_id: traceId,
         dotted_order: toolDottedOrder,
         extra: {
-          metadata: { thread_id: sessionId, ls_integration: "claude-code", ...customMetadata }
+          metadata: codingAgentMetadata({
+            sessionId,
+            base: customMetadata,
+            turnId,
+            turnNumber: turnNum,
+            runtimeVersion,
+            toolName: toolCall.tool_use.name,
+            runName: toolCall.tool_use.name
+          })
         }
       });
       await runTree2.postRun();
@@ -8439,18 +8535,22 @@ async function traceTurn(options) {
         messages: [{ role: "assistant", content: assistantContent }]
       },
       extra: {
-        metadata: {
-          thread_id: sessionId,
-          ls_integration: "claude-code",
-          ls_provider: "anthropic",
-          ls_model_name: llmCall.model,
-          ls_invocation_params: {
-            model: llmCall.model
-          },
-          usage_metadata: buildUsageMetadata(llmCall.usage),
-          ...llmCall.synthetic ? { synthetic: true } : {},
-          ...customMetadata
-        }
+        metadata: codingAgentMetadata({
+          sessionId,
+          base: customMetadata,
+          turnId,
+          turnNumber: turnNum,
+          runtimeVersion,
+          runSpecific: {
+            ls_provider: "anthropic",
+            ls_model_name: llmCall.model,
+            ls_invocation_params: {
+              model: llmCall.model
+            },
+            usage_metadata: buildUsageMetadata(llmCall.usage),
+            ...llmCall.synthetic ? { synthetic: true } : {}
+          }
+        })
       }
     });
     await runTree.patchRun({ excludeInputs: true });
@@ -8481,12 +8581,16 @@ async function traceTurn(options) {
       outputs: { messages: turnOutputs },
       error: error2,
       extra: {
-        metadata: {
-          thread_id: sessionId,
-          ls_integration: "claude-code",
-          turn_number: turnNum,
-          ...customMetadata
-        }
+        metadata: codingAgentMetadata({
+          sessionId,
+          base: customMetadata,
+          turnId,
+          turnNumber: turnNum,
+          runtimeVersion,
+          approvalPolicy,
+          legacyRole: "root"
+          // DEPRECATED compat alias ls_agent_type="root".
+        })
       }
     });
     await runTree.patchRun({ excludeInputs: true });
@@ -8496,7 +8600,7 @@ async function traceTurn(options) {
   return taskRunMap;
 }
 async function tracePendingSubagents(options) {
-  const { sessionId, pendingSubagents, taskRunMap, parentTraceId, project, customMetadata } = options;
+  const { sessionId, pendingSubagents, taskRunMap, parentTraceId, project, customMetadata, runtimeVersion, turnId, turnNumber } = options;
   if (!client && !replicas) {
     throw new Error("LangSmith client not initialized \u2014 call initTracing() first");
   }
@@ -8540,14 +8644,22 @@ async function tracePendingSubagents(options) {
           trace_id: deferred.trace_id,
           dotted_order: agentToolDottedOrder,
           extra: {
-            metadata: {
-              thread_id: sessionId,
-              ls_integration: "claude-code",
-              tool_name: "Agent",
-              agent_type: toolName,
-              agent_id: subagent.agent_id,
-              ...customMetadata
-            }
+            metadata: codingAgentMetadata({
+              sessionId,
+              base: customMetadata,
+              runtimeVersion,
+              turnId,
+              turnNumber,
+              // run_type "tool" (run name "Agent", native tool "Task").
+              toolName: "Task",
+              runName: "Agent",
+              runSpecific: {
+                agent_type: toolName,
+                // DEPRECATED compat alias.
+                agent_id: subagent.agent_id
+                // DEPRECATED compat alias.
+              }
+            })
           }
         });
         await runTree2.postRun();
@@ -8569,14 +8681,19 @@ async function tracePendingSubagents(options) {
         trace_id: parentTraceId,
         dotted_order: subagentChainDottedOrder,
         extra: {
-          metadata: {
-            thread_id: sessionId,
-            ls_integration: "claude-code",
-            ls_agent_type: "subagent",
-            agent_type: toolName,
-            agent_id: subagent.agent_id,
-            ...customMetadata
-          }
+          metadata: codingAgentMetadata({
+            sessionId,
+            base: customMetadata,
+            runtimeVersion,
+            turnId,
+            turnNumber,
+            legacyRole: "subagent",
+            // DEPRECATED compat alias.
+            subagentId: subagent.agent_id,
+            // → ls_subagent_id (+ agent_id alias).
+            subagentType: toolName
+            // → ls_subagent_type (+ agent_type alias).
+          })
         }
       });
       await runTree.postRun();
@@ -8590,7 +8707,8 @@ async function tracePendingSubagents(options) {
           existingTaskRunMap: void 0,
           traceId: parentTraceId,
           parentDottedOrder: subagentChainDottedOrder,
-          customMetadata
+          customMetadata,
+          runtimeVersion
         });
       }
       log(`Traced subagent ${toolName} (${subagent.agent_id}): ${subagentTurns.length} turn(s)`);
@@ -8605,6 +8723,13 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
+var LS_INTEGRATION_VERSION = true ? "0.1.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var PROVIDER_HOSTS = {
+  github: "github.com",
+  gitlab: "gitlab.com",
+  bitbucket: "bitbucket.org",
+  devAzure: "dev.azure.com"
+};
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -8665,6 +8790,26 @@ function getRepoName(cwd) {
   }
   return void 0;
 }
+function getGitInfo(cwd) {
+  const result = {};
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5e3
+    }).trim();
+    if (branch && branch !== "HEAD")
+      result.branch = branch;
+  } catch {
+  }
+  try {
+    const commit = execSync("git rev-parse HEAD", { cwd, encoding: "utf-8", timeout: 5e3 }).trim();
+    if (commit)
+      result.commit = commit;
+  } catch {
+  }
+  return result;
+}
 function loadConfig(options) {
   const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
@@ -8701,15 +8846,34 @@ function loadConfig(options) {
   const localUsername = readLocalUsername();
   const identityMetadata = { local_username: localUsername };
   if (anthropicUserId) {
+    identityMetadata.user_id = anthropicUserId;
     identityMetadata.anthropic_user_id = anthropicUserId;
+  }
+  const contractMetadata = {
+    ls_agent_kind: "coding_agent",
+    ls_integration: "claude-code",
+    ls_agent_runtime: "Claude Code",
+    ls_trace_schema_version: "coding-agent-v1",
+    cwd
+  };
+  if (LS_INTEGRATION_VERSION) {
+    contractMetadata.ls_integration_version = LS_INTEGRATION_VERSION;
   }
   const repoMetadata = {};
   const repoName = getRepoName(cwd);
   if (repoName != null) {
     repoMetadata.repository_name = repoName.name;
     repoMetadata.repository_provider = repoName.provider;
+    const host = PROVIDER_HOSTS[repoName.provider];
+    if (host)
+      repoMetadata.repository_url = `https://${host}/${repoName.name}`;
   }
-  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
+  const gitInfo = getGitInfo(cwd);
+  if (gitInfo.branch)
+    repoMetadata.git_branch = gitInfo.branch;
+  if (gitInfo.commit)
+    repoMetadata.git_commit_sha = gitInfo.commit;
+  customMetadata = { ...contractMetadata, ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,
@@ -8723,8 +8887,8 @@ function loadConfig(options) {
 }
 
 // dist/utils/hook-init.js
-function initHook() {
-  const config = loadConfig();
+function initHook(cwd) {
+  const config = loadConfig({ cwd });
   initLogger(config.debug);
   if (process.env.TRACE_TO_LANGSMITH?.toLowerCase() !== "true") {
     return null;
@@ -8760,7 +8924,7 @@ function readStdin() {
 async function main() {
   const startTime = Date.now();
   const input = await readStdin();
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config)
     return;
   debug(`Stop hook started, session=${input.session_id}`);
@@ -8777,6 +8941,8 @@ async function main() {
   const state = loadState(config.stateFilePath);
   const sessionState = getSessionState(state, input.session_id);
   debug(`Last line: ${sessionState.last_line}, turn count: ${sessionState.turn_count}`);
+  const runtimeVersion = sessionState.runtime_version ?? readRuntimeVersion(transcriptPath);
+  const approvalPolicy = sessionState.approval_policy ?? input.permission_mode;
   await new Promise((r) => setTimeout(r, 200));
   const { messages, lastLine } = readTranscript(transcriptPath, sessionState.last_line);
   if (messages.length === 0) {
@@ -8831,6 +8997,8 @@ async function main() {
         turnNum,
         project: config.project,
         customMetadata: config.customMetadata,
+        runtimeVersion,
+        approvalPolicy,
         parentRunId,
         existingTaskRunMap,
         tracedToolUseIds,
@@ -8862,13 +9030,16 @@ async function main() {
           messages: [{ role: "assistant", content: input.last_assistant_message }]
         },
         extra: {
-          metadata: {
-            thread_id: input.session_id,
-            ls_integration: "claude-code",
-            ls_agent_type: "root",
-            turn_number: sessionState.current_turn_number,
-            ...config.customMetadata
-          }
+          metadata: codingAgentMetadata({
+            sessionId: input.session_id,
+            base: config.customMetadata,
+            turnId: turns[turns.length - 1]?.promptId,
+            turnNumber: sessionState.current_turn_number,
+            runtimeVersion,
+            approvalPolicy,
+            legacyRole: "root"
+            // DEPRECATED compat alias ls_agent_type="root".
+          })
         }
       });
       await runTree.patchRun({ excludeInputs: true });
@@ -8889,7 +9060,10 @@ async function main() {
       taskRunMap: mergedTaskRunMap,
       parentTraceId: freshSession.current_trace_id,
       project: config.project,
-      customMetadata: config.customMetadata
+      customMetadata: config.customMetadata,
+      runtimeVersion,
+      turnId: turns[turns.length - 1]?.promptId,
+      turnNumber: sessionState.current_turn_number
     });
   }
   const savedLastLine = tracedTurns > 0 ? lastLine : sessionState.last_line;

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -591,7 +591,7 @@ var require_dist = __commonJS({
 });
 
 // dist/transcript.js
-import { readFileSync, statSync, openSync, readSync, closeSync } from "node:fs";
+import { readFileSync, statSync, fstatSync, openSync, readSync, closeSync } from "node:fs";
 var MAX_FULL_READ_BYTES = 50 * 1024 * 1024;
 function readTranscript(filePath, afterLine = -1) {
   let size;
@@ -664,14 +664,14 @@ function readTranscript(filePath, afterLine = -1) {
 function readRuntimeVersion(filePath) {
   let fd;
   try {
-    const size = statSync(filePath).size;
+    fd = openSync(filePath, "r");
+    const size = fstatSync(fd).size;
     if (size === 0)
       return void 0;
     const window2 = 64 * 1024;
     const start = Math.max(0, size - window2);
     const len = size - start;
     const buf = Buffer.alloc(len);
-    fd = openSync(filePath, "r");
     readSync(fd, buf, 0, len, start);
     const text = buf.toString("utf-8");
     const lines = text.split("\n").filter((l) => l.trim() !== "");

--- a/bundle/subagent-stop.js
+++ b/bundle/subagent-stop.js
@@ -104,6 +104,13 @@ import { readFileSync as readFileSync2 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
+var LS_INTEGRATION_VERSION = true ? "0.1.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var PROVIDER_HOSTS = {
+  github: "github.com",
+  gitlab: "gitlab.com",
+  bitbucket: "bitbucket.org",
+  devAzure: "dev.azure.com"
+};
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -164,6 +171,26 @@ function getRepoName(cwd) {
   }
   return void 0;
 }
+function getGitInfo(cwd) {
+  const result = {};
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5e3
+    }).trim();
+    if (branch && branch !== "HEAD")
+      result.branch = branch;
+  } catch {
+  }
+  try {
+    const commit = execSync("git rev-parse HEAD", { cwd, encoding: "utf-8", timeout: 5e3 }).trim();
+    if (commit)
+      result.commit = commit;
+  } catch {
+  }
+  return result;
+}
 function loadConfig(options) {
   const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
@@ -200,15 +227,34 @@ function loadConfig(options) {
   const localUsername = readLocalUsername();
   const identityMetadata = { local_username: localUsername };
   if (anthropicUserId) {
+    identityMetadata.user_id = anthropicUserId;
     identityMetadata.anthropic_user_id = anthropicUserId;
+  }
+  const contractMetadata = {
+    ls_agent_kind: "coding_agent",
+    ls_integration: "claude-code",
+    ls_agent_runtime: "Claude Code",
+    ls_trace_schema_version: "coding-agent-v1",
+    cwd
+  };
+  if (LS_INTEGRATION_VERSION) {
+    contractMetadata.ls_integration_version = LS_INTEGRATION_VERSION;
   }
   const repoMetadata = {};
   const repoName = getRepoName(cwd);
   if (repoName != null) {
     repoMetadata.repository_name = repoName.name;
     repoMetadata.repository_provider = repoName.provider;
+    const host = PROVIDER_HOSTS[repoName.provider];
+    if (host)
+      repoMetadata.repository_url = `https://${host}/${repoName.name}`;
   }
-  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
+  const gitInfo = getGitInfo(cwd);
+  if (gitInfo.branch)
+    repoMetadata.git_branch = gitInfo.branch;
+  if (gitInfo.commit)
+    repoMetadata.git_commit_sha = gitInfo.commit;
+  customMetadata = { ...contractMetadata, ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,
@@ -222,8 +268,8 @@ function loadConfig(options) {
 }
 
 // dist/utils/hook-init.js
-function initHook() {
-  const config = loadConfig();
+function initHook(cwd) {
+  const config = loadConfig({ cwd });
   initLogger(config.debug);
   if (process.env.TRACE_TO_LANGSMITH?.toLowerCase() !== "true") {
     return null;
@@ -258,7 +304,7 @@ function readStdin() {
 // dist/hooks/subagent-stop.js
 async function main() {
   const input = await readStdin();
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config)
     return;
   debug(`SubagentStop hook: agent_id=${input.agent_id}, type=${input.agent_type}`);

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -7944,7 +7944,7 @@ function debug(message) {
 }
 
 // dist/transcript.js
-import { readFileSync as readFileSync3, statSync as statSync2, openSync, readSync, closeSync } from "node:fs";
+import { readFileSync as readFileSync3, statSync as statSync2, fstatSync, openSync, readSync, closeSync } from "node:fs";
 var MAX_FULL_READ_BYTES = 50 * 1024 * 1024;
 function readTranscript(filePath, afterLine = -1) {
   let size;
@@ -8056,14 +8056,14 @@ function getTranscriptEndLine(filePath) {
 function readRuntimeVersion(filePath) {
   let fd;
   try {
-    const size = statSync2(filePath).size;
+    fd = openSync(filePath, "r");
+    const size = fstatSync(fd).size;
     if (size === 0)
       return void 0;
     const window2 = 64 * 1024;
     const start = Math.max(0, size - window2);
     const len = size - start;
     const buf = Buffer.alloc(len);
-    fd = openSync(filePath, "r");
     readSync(fd, buf, 0, len, start);
     const text = buf.toString("utf-8");
     const lines = text.split("\n").filter((l) => l.trim() !== "");

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -8053,6 +8053,36 @@ function getTranscriptEndLine(filePath) {
     return -1;
   }
 }
+function readRuntimeVersion(filePath) {
+  let fd;
+  try {
+    const size = statSync2(filePath).size;
+    if (size === 0)
+      return void 0;
+    const window2 = 64 * 1024;
+    const start = Math.max(0, size - window2);
+    const len = size - start;
+    const buf = Buffer.alloc(len);
+    fd = openSync(filePath, "r");
+    readSync(fd, buf, 0, len, start);
+    const text = buf.toString("utf-8");
+    const lines = text.split("\n").filter((l) => l.trim() !== "");
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const parsed = JSON.parse(lines[i]);
+        if (typeof parsed.version === "string" && parsed.version.length > 0) {
+          return parsed.version;
+        }
+      } catch {
+      }
+    }
+  } catch {
+  } finally {
+    if (fd !== void 0)
+      closeSync(fd);
+  }
+  return void 0;
+}
 function isHumanMessage(msg) {
   if (msg.type !== "user")
     return false;
@@ -8169,7 +8199,8 @@ function groupIntoTurns(messages) {
       userContent: currentUser.message.content,
       userTimestamp: currentUser.timestamp,
       llmCalls,
-      isComplete
+      isComplete,
+      promptId: currentUser.promptId
     });
   }
   for (const msg of messages) {
@@ -8268,6 +8299,51 @@ var SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 var USER_PROMPT_TURN_NAME = "Claude Code Turn";
 var ASSISTANT_RUN_NAME = "Claude";
 
+// dist/metadata.js
+var LS_AGENT_KIND = "coding_agent";
+var LS_INTEGRATION = "claude-code";
+var LS_AGENT_RUNTIME = "Claude Code";
+var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
+function codingAgentMetadata(opts) {
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, legacyRole, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const meta = {
+    // Identity & grouping — always present.
+    ls_agent_kind: LS_AGENT_KIND,
+    ls_integration: LS_INTEGRATION,
+    ls_agent_runtime: LS_AGENT_RUNTIME,
+    ls_trace_schema_version: LS_TRACE_SCHEMA_VERSION,
+    thread_id: sessionId
+  };
+  if (turnId)
+    meta.turn_id = turnId;
+  if (typeof turnNumber === "number")
+    meta.turn_number = turnNumber;
+  if (runtimeVersion)
+    meta.ls_agent_runtime_version = runtimeVersion;
+  if (approvalPolicy)
+    meta.approval_policy = approvalPolicy;
+  if (legacyRole)
+    meta.ls_agent_type = legacyRole;
+  if (subagentId) {
+    meta.ls_subagent_id = subagentId;
+    meta.agent_id = subagentId;
+  }
+  if (subagentType) {
+    meta.ls_subagent_type = subagentType;
+    meta.agent_type = subagentType;
+  }
+  if (toolName) {
+    meta.tool_name = toolName;
+    if (runName && toolName !== runName)
+      meta.ls_tool_name = toolName;
+  }
+  return {
+    ...meta,
+    ...runSpecific,
+    ...base
+  };
+}
+
 // dist/langsmith.js
 var client = void 0;
 var replicas = void 0;
@@ -8336,7 +8412,8 @@ function buildUsageMetadata(usage) {
   };
 }
 async function traceTurn(options) {
-  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata } = options;
+  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata, runtimeVersion, approvalPolicy } = options;
+  const turnId = turn.promptId;
   let traceId = providedTraceId;
   let parentDottedOrder = providedParentDottedOrder;
   if (!client && !replicas) {
@@ -8368,7 +8445,18 @@ async function traceTurn(options) {
       start_time: turn.userTimestamp,
       trace_id: traceId,
       dotted_order: parentDottedOrder,
-      ...customMetadata ? { extra: { metadata: { ...customMetadata } } } : {}
+      extra: {
+        metadata: codingAgentMetadata({
+          sessionId,
+          base: customMetadata,
+          turnId,
+          turnNumber: turnNum,
+          runtimeVersion,
+          approvalPolicy,
+          legacyRole: "root"
+          // DEPRECATED compat alias ls_agent_type="root".
+        })
+      }
     });
     await runTree.postRun();
   }
@@ -8428,7 +8516,15 @@ async function traceTurn(options) {
         trace_id: traceId,
         dotted_order: toolDottedOrder,
         extra: {
-          metadata: { thread_id: sessionId, ls_integration: "claude-code", ...customMetadata }
+          metadata: codingAgentMetadata({
+            sessionId,
+            base: customMetadata,
+            turnId,
+            turnNumber: turnNum,
+            runtimeVersion,
+            toolName: toolCall.tool_use.name,
+            runName: toolCall.tool_use.name
+          })
         }
       });
       await runTree2.postRun();
@@ -8458,18 +8554,22 @@ async function traceTurn(options) {
         messages: [{ role: "assistant", content: assistantContent }]
       },
       extra: {
-        metadata: {
-          thread_id: sessionId,
-          ls_integration: "claude-code",
-          ls_provider: "anthropic",
-          ls_model_name: llmCall.model,
-          ls_invocation_params: {
-            model: llmCall.model
-          },
-          usage_metadata: buildUsageMetadata(llmCall.usage),
-          ...llmCall.synthetic ? { synthetic: true } : {},
-          ...customMetadata
-        }
+        metadata: codingAgentMetadata({
+          sessionId,
+          base: customMetadata,
+          turnId,
+          turnNumber: turnNum,
+          runtimeVersion,
+          runSpecific: {
+            ls_provider: "anthropic",
+            ls_model_name: llmCall.model,
+            ls_invocation_params: {
+              model: llmCall.model
+            },
+            usage_metadata: buildUsageMetadata(llmCall.usage),
+            ...llmCall.synthetic ? { synthetic: true } : {}
+          }
+        })
       }
     });
     await runTree.patchRun({ excludeInputs: true });
@@ -8500,12 +8600,16 @@ async function traceTurn(options) {
       outputs: { messages: turnOutputs },
       error: error2,
       extra: {
-        metadata: {
-          thread_id: sessionId,
-          ls_integration: "claude-code",
-          turn_number: turnNum,
-          ...customMetadata
-        }
+        metadata: codingAgentMetadata({
+          sessionId,
+          base: customMetadata,
+          turnId,
+          turnNumber: turnNum,
+          runtimeVersion,
+          approvalPolicy,
+          legacyRole: "root"
+          // DEPRECATED compat alias ls_agent_type="root".
+        })
       }
     });
     await runTree.patchRun({ excludeInputs: true });
@@ -8515,18 +8619,21 @@ async function traceTurn(options) {
   return taskRunMap;
 }
 async function closeInterruptedTurn(options) {
-  const { sessionId, sessionState, transcriptPath, project, stateFilePath, customMetadata } = options;
+  const { sessionId, sessionState, transcriptPath, project, stateFilePath, customMetadata, runtimeVersion, approvalPolicy } = options;
   if (!client && !replicas)
     throw new Error("LangSmith client not initialized \u2014 call initTracing() first");
   let lastLine = sessionState.last_line;
   let turnsTraced = 0;
   let taskRunMap = sessionState.task_run_map ?? {};
+  let turnId;
+  const turnNumber = sessionState.current_turn_number;
   if (transcriptPath) {
     try {
       const { messages, lastLine: newLastLine } = readTranscript(transcriptPath, sessionState.last_line);
       if (messages.length > 0) {
         const turns = groupIntoTurns(messages);
         if (turns.length > 0) {
+          turnId = turns[turns.length - 1].promptId;
           await traceTurn({
             turn: turns[turns.length - 1],
             sessionId,
@@ -8536,7 +8643,10 @@ async function closeInterruptedTurn(options) {
             existingTaskRunMap: taskRunMap,
             tracedToolUseIds: new Set(sessionState.traced_tool_use_ids ?? []),
             traceId: sessionState.current_trace_id,
-            parentDottedOrder: sessionState.current_dotted_order
+            parentDottedOrder: sessionState.current_dotted_order,
+            customMetadata,
+            runtimeVersion,
+            approvalPolicy
           });
           lastLine = newLastLine;
           turnsTraced = 1;
@@ -8557,7 +8667,10 @@ async function closeInterruptedTurn(options) {
         taskRunMap,
         parentTraceId: sessionState.current_trace_id,
         project,
-        customMetadata
+        customMetadata,
+        runtimeVersion,
+        turnId,
+        turnNumber
       });
     } catch (err) {
       error(`Failed to trace pending subagents on interrupt: ${err}`);
@@ -8577,12 +8690,15 @@ async function closeInterruptedTurn(options) {
     end_time: (/* @__PURE__ */ new Date()).toISOString(),
     error: "User interrupt",
     extra: {
-      metadata: {
-        thread_id: sessionId,
-        ls_integration: "claude-code",
-        turn_number: sessionState.current_turn_number,
-        ...customMetadata
-      }
+      metadata: codingAgentMetadata({
+        sessionId,
+        base: customMetadata,
+        turnNumber: sessionState.current_turn_number,
+        runtimeVersion,
+        approvalPolicy,
+        legacyRole: "root"
+        // DEPRECATED compat alias ls_agent_type="root".
+      })
     }
   });
   await runTree.patchRun({ excludeInputs: true });
@@ -8590,7 +8706,7 @@ async function closeInterruptedTurn(options) {
   return { lastLine, turnsTraced };
 }
 async function tracePendingSubagents(options) {
-  const { sessionId, pendingSubagents, taskRunMap, parentTraceId, project, customMetadata } = options;
+  const { sessionId, pendingSubagents, taskRunMap, parentTraceId, project, customMetadata, runtimeVersion, turnId, turnNumber } = options;
   if (!client && !replicas) {
     throw new Error("LangSmith client not initialized \u2014 call initTracing() first");
   }
@@ -8634,14 +8750,22 @@ async function tracePendingSubagents(options) {
           trace_id: deferred.trace_id,
           dotted_order: agentToolDottedOrder,
           extra: {
-            metadata: {
-              thread_id: sessionId,
-              ls_integration: "claude-code",
-              tool_name: "Agent",
-              agent_type: toolName,
-              agent_id: subagent.agent_id,
-              ...customMetadata
-            }
+            metadata: codingAgentMetadata({
+              sessionId,
+              base: customMetadata,
+              runtimeVersion,
+              turnId,
+              turnNumber,
+              // run_type "tool" (run name "Agent", native tool "Task").
+              toolName: "Task",
+              runName: "Agent",
+              runSpecific: {
+                agent_type: toolName,
+                // DEPRECATED compat alias.
+                agent_id: subagent.agent_id
+                // DEPRECATED compat alias.
+              }
+            })
           }
         });
         await runTree2.postRun();
@@ -8663,14 +8787,19 @@ async function tracePendingSubagents(options) {
         trace_id: parentTraceId,
         dotted_order: subagentChainDottedOrder,
         extra: {
-          metadata: {
-            thread_id: sessionId,
-            ls_integration: "claude-code",
-            ls_agent_type: "subagent",
-            agent_type: toolName,
-            agent_id: subagent.agent_id,
-            ...customMetadata
-          }
+          metadata: codingAgentMetadata({
+            sessionId,
+            base: customMetadata,
+            runtimeVersion,
+            turnId,
+            turnNumber,
+            legacyRole: "subagent",
+            // DEPRECATED compat alias.
+            subagentId: subagent.agent_id,
+            // → ls_subagent_id (+ agent_id alias).
+            subagentType: toolName
+            // → ls_subagent_type (+ agent_type alias).
+          })
         }
       });
       await runTree.postRun();
@@ -8684,7 +8813,8 @@ async function tracePendingSubagents(options) {
           existingTaskRunMap: void 0,
           traceId: parentTraceId,
           parentDottedOrder: subagentChainDottedOrder,
-          customMetadata
+          customMetadata,
+          runtimeVersion
         });
       }
       log(`Traced subagent ${toolName} (${subagent.agent_id}): ${subagentTurns.length} turn(s)`);
@@ -8699,6 +8829,13 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
+var LS_INTEGRATION_VERSION = true ? "0.1.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var PROVIDER_HOSTS = {
+  github: "github.com",
+  gitlab: "gitlab.com",
+  bitbucket: "bitbucket.org",
+  devAzure: "dev.azure.com"
+};
 function readAnthropicUserId() {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE;
   if (!homeDir)
@@ -8759,6 +8896,26 @@ function getRepoName(cwd) {
   }
   return void 0;
 }
+function getGitInfo(cwd) {
+  const result = {};
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5e3
+    }).trim();
+    if (branch && branch !== "HEAD")
+      result.branch = branch;
+  } catch {
+  }
+  try {
+    const commit = execSync("git rev-parse HEAD", { cwd, encoding: "utf-8", timeout: 5e3 }).trim();
+    if (commit)
+      result.commit = commit;
+  } catch {
+  }
+  return result;
+}
 function loadConfig(options) {
   const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
@@ -8795,15 +8952,34 @@ function loadConfig(options) {
   const localUsername = readLocalUsername();
   const identityMetadata = { local_username: localUsername };
   if (anthropicUserId) {
+    identityMetadata.user_id = anthropicUserId;
     identityMetadata.anthropic_user_id = anthropicUserId;
+  }
+  const contractMetadata = {
+    ls_agent_kind: "coding_agent",
+    ls_integration: "claude-code",
+    ls_agent_runtime: "Claude Code",
+    ls_trace_schema_version: "coding-agent-v1",
+    cwd
+  };
+  if (LS_INTEGRATION_VERSION) {
+    contractMetadata.ls_integration_version = LS_INTEGRATION_VERSION;
   }
   const repoMetadata = {};
   const repoName = getRepoName(cwd);
   if (repoName != null) {
     repoMetadata.repository_name = repoName.name;
     repoMetadata.repository_provider = repoName.provider;
+    const host = PROVIDER_HOSTS[repoName.provider];
+    if (host)
+      repoMetadata.repository_url = `https://${host}/${repoName.name}`;
   }
-  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
+  const gitInfo = getGitInfo(cwd);
+  if (gitInfo.branch)
+    repoMetadata.git_branch = gitInfo.branch;
+  if (gitInfo.commit)
+    repoMetadata.git_commit_sha = gitInfo.commit;
+  customMetadata = { ...contractMetadata, ...identityMetadata, ...repoMetadata, ...customMetadata };
   return {
     apiKey,
     project,
@@ -8817,8 +8993,8 @@ function loadConfig(options) {
 }
 
 // dist/utils/hook-init.js
-function initHook() {
-  const config = loadConfig();
+function initHook(cwd) {
+  const config = loadConfig({ cwd });
   initLogger(config.debug);
   if (process.env.TRACE_TO_LANGSMITH?.toLowerCase() !== "true") {
     return null;
@@ -8854,7 +9030,7 @@ function readStdin() {
 async function main() {
   const hookStartTime = Date.now();
   const input = await readStdin();
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config)
     return;
   debug(`UserPromptSubmit hook started, session=${input.session_id}`);
@@ -8865,6 +9041,9 @@ async function main() {
   const client2 = initTracing(config.apiKey, config.apiBaseUrl, config.replicas);
   const state = loadState(config.stateFilePath);
   const sessionState = getSessionState(state, input.session_id);
+  const expandedTranscript = expandHome(input.transcript_path);
+  const runtimeVersion = (expandedTranscript ? readRuntimeVersion(expandedTranscript) : void 0) ?? sessionState.runtime_version;
+  const approvalPolicy = input.permission_mode;
   let interruptedLastLine = sessionState.last_line;
   if (interruptedLastLine === -1 && input.transcript_path) {
     const transcriptPath = expandHome(input.transcript_path);
@@ -8884,7 +9063,9 @@ async function main() {
         transcriptPath: expandHome(input.transcript_path),
         project: config.project,
         stateFilePath: config.stateFilePath,
-        customMetadata: config.customMetadata
+        customMetadata: config.customMetadata,
+        runtimeVersion,
+        approvalPolicy
       });
       interruptedLastLine = lastLine;
       interruptedTurnsTraced = turnsTraced;
@@ -8922,7 +9103,18 @@ async function main() {
     trace_id: traceId,
     dotted_order: dottedOrder,
     ...parentRunId ? { parent_run_id: parentRunId } : {},
-    ...config.customMetadata ? { extra: { metadata: { ...config.customMetadata } } } : {}
+    extra: {
+      metadata: codingAgentMetadata({
+        sessionId: input.session_id,
+        base: config.customMetadata,
+        // turn_id (promptId) isn't known yet; Stop stamps it on completion.
+        turnNumber: turnNum,
+        runtimeVersion,
+        approvalPolicy,
+        legacyRole: "root"
+        // DEPRECATED compat alias ls_agent_type="root".
+      })
+    }
   });
   await runTree.postRun();
   debug(`Created initial run ${runId} for turn ${turnNum}`);
@@ -8938,6 +9130,9 @@ async function main() {
         current_parent_run_id: parentRunId,
         current_turn_number: turnNum,
         current_turn_start: startTime,
+        // Persisted so the closing hooks can stamp them onto their runs.
+        approval_policy: approvalPolicy,
+        ...runtimeVersion ? { runtime_version: runtimeVersion } : {},
         // Advance past the interrupted turn's messages so Stop doesn't re-trace them
         last_line: interruptedLastLine,
         turn_count: ss.turn_count + interruptedTurnsTraced,

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,5 +1,10 @@
 import { build } from "esbuild";
-import { chmodSync } from "node:fs";
+import { chmodSync, readFileSync } from "node:fs";
+
+// Read the plugin version at BUILD TIME and inject it as a global constant.
+// The runtime bundle has no package.json, so we cannot require("./package.json")
+// at runtime — esbuild `define` substitutes the literal into the bundle instead.
+const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf-8"));
 
 const entryPoints = [
   "dist/hooks/user-prompt-submit.js",
@@ -22,6 +27,11 @@ await build({
   // tsc output already has shebangs; esbuild strips them during bundling
   // Mark node builtins as external (they're available at runtime)
   external: ["node:*"],
+  define: {
+    // Build-time injection of the plugin (integration) version. Consumed by
+    // config.ts via `typeof __LS_INTEGRATION_VERSION__`.
+    __LS_INTEGRATION_VERSION__: JSON.stringify(pkg.version),
+  },
 });
 
 // Make hooks executable

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -291,4 +291,57 @@ describe("loadConfig", () => {
       repository_provider: provider,
     });
   });
+
+  describe("coding-agent-v1 contract metadata", () => {
+    it("includes the frozen identity literals and cwd", () => {
+      const config = loadConfig({ cwd });
+      expect(config.customMetadata).toMatchObject({
+        ls_agent_kind: "coding_agent",
+        ls_integration: "claude-code",
+        ls_agent_runtime: "Claude Code",
+        ls_trace_schema_version: "coding-agent-v1",
+        cwd,
+      });
+    });
+
+    it("surfaces the hashed anthropic id as user_id (preferred) and keeps the compat alias", () => {
+      writeFileSync(join(tmpHome, ".claude.json"), JSON.stringify({ userID: "hashed-123" }));
+      const config = loadConfig({ cwd });
+      expect(config.customMetadata).toMatchObject({
+        user_id: "hashed-123",
+        anthropic_user_id: "hashed-123", // DEPRECATED compat alias
+      });
+    });
+
+    it("derives repository_url + git_branch + git_commit_sha", () => {
+      vi.mocked(execSync).mockImplementation((command: string) => {
+        if (command.includes("remote -v")) {
+          const url = "git@github.com:langchain-ai/example.git";
+          return [`origin\t${url} (fetch)`, `origin\t${url} (push)`].join("\n");
+        }
+        if (command.includes("abbrev-ref")) return "feature/my-branch\n";
+        if (command.includes("rev-parse HEAD")) return "deadbeefcafe1234\n";
+        return "";
+      });
+      const config = loadConfig({ cwd: __dirname });
+      expect(config.customMetadata).toMatchObject({
+        repository_name: "langchain-ai/example",
+        repository_provider: "github",
+        repository_url: "https://github.com/langchain-ai/example",
+        git_branch: "feature/my-branch",
+        git_commit_sha: "deadbeefcafe1234",
+      });
+    });
+
+    it("omits git_branch for a detached HEAD", () => {
+      vi.mocked(execSync).mockImplementation((command: string) => {
+        if (command.includes("abbrev-ref")) return "HEAD\n";
+        if (command.includes("rev-parse HEAD")) return "deadbeef\n";
+        return "";
+      });
+      const config = loadConfig({ cwd: __dirname });
+      expect(config.customMetadata).not.toHaveProperty("git_branch");
+      expect(config.customMetadata).toMatchObject({ git_commit_sha: "deadbeef" });
+    });
+  });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,24 @@ import { execSync } from "node:child_process";
  */
 
 /**
+ * Plugin version, injected at build time by esbuild `define` (no runtime
+ * package.json). `typeof` guards the non-bundled case; env is the fallback.
+ */
+declare const __LS_INTEGRATION_VERSION__: string;
+export const LS_INTEGRATION_VERSION: string | undefined =
+  typeof __LS_INTEGRATION_VERSION__ !== "undefined"
+    ? __LS_INTEGRATION_VERSION__
+    : process.env.CC_LANGSMITH_INTEGRATION_VERSION || undefined;
+
+/** Host used to build a canonical https repository_url from a parsed provider. */
+const PROVIDER_HOSTS: Record<string, string> = {
+  github: "github.com",
+  gitlab: "gitlab.com",
+  bitbucket: "bitbucket.org",
+  devAzure: "dev.azure.com",
+};
+
+/**
  * Read the Anthropic user ID from `~/.claude.json` if available.
  *
  * Claude Code stores a stable per-installation hashed user identifier as
@@ -49,7 +67,7 @@ export interface Config {
   /** Dotted-order string of an existing LangSmith run to nest all traces under. */
   parentDottedOrder?: string;
   replicas?: RunTreeConfig["replicas"];
-  /** Custom metadata to attach to root turn runs (parsed from CC_LANGSMITH_METADATA). */
+  /** Base metadata (static contract keys + user CC_LANGSMITH_METADATA) for every run. */
   customMetadata?: Record<string, unknown>;
 }
 
@@ -111,6 +129,29 @@ export function getRepoName(cwd: string): { provider: string; name: string } | u
   return undefined;
 }
 
+/** Read the current git branch and commit SHA via the git CLI (omitted if absent). */
+export function getGitInfo(cwd: string): { branch?: string; commit?: string } {
+  const result: { branch?: string; commit?: string } = {};
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5000,
+    }).trim();
+    // "HEAD" means detached — no branch name available.
+    if (branch && branch !== "HEAD") result.branch = branch;
+  } catch {
+    // Not a git repo / git unavailable — skip.
+  }
+  try {
+    const commit = execSync("git rev-parse HEAD", { cwd, encoding: "utf-8", timeout: 5000 }).trim();
+    if (commit) result.commit = commit;
+  } catch {
+    // Not a git repo / git unavailable — skip.
+  }
+  return result;
+}
+
 export function loadConfig(options?: { cwd?: string }): Config {
   const cwd = options?.cwd ?? process.cwd();
   const apiKey = process.env.CC_LANGSMITH_API_KEY ?? process.env.LANGSMITH_API_KEY ?? "";
@@ -160,7 +201,22 @@ export function loadConfig(options?: { cwd?: string }): Config {
   const localUsername = readLocalUsername();
   const identityMetadata: Record<string, unknown> = { local_username: localUsername };
   if (anthropicUserId) {
+    // Standardized coding-agent-v1 key (preferred over local_username)...
+    identityMetadata.user_id = anthropicUserId;
+    // ...and the original key, kept as a DEPRECATED compat alias (≥1 release).
     identityMetadata.anthropic_user_id = anthropicUserId;
+  }
+
+  // coding-agent-v1 static identity literals + versions, merged onto every run.
+  const contractMetadata: Record<string, unknown> = {
+    ls_agent_kind: "coding_agent",
+    ls_integration: "claude-code",
+    ls_agent_runtime: "Claude Code",
+    ls_trace_schema_version: "coding-agent-v1",
+    cwd,
+  };
+  if (LS_INTEGRATION_VERSION) {
+    contractMetadata.ls_integration_version = LS_INTEGRATION_VERSION;
   }
 
   // Attach git repo metadata if available, to attribute runs to a specific codebase.
@@ -169,9 +225,14 @@ export function loadConfig(options?: { cwd?: string }): Config {
   if (repoName != null) {
     repoMetadata.repository_name = repoName.name;
     repoMetadata.repository_provider = repoName.provider;
+    const host = PROVIDER_HOSTS[repoName.provider];
+    if (host) repoMetadata.repository_url = `https://${host}/${repoName.name}`;
   }
+  const gitInfo = getGitInfo(cwd);
+  if (gitInfo.branch) repoMetadata.git_branch = gitInfo.branch;
+  if (gitInfo.commit) repoMetadata.git_commit_sha = gitInfo.commit;
 
-  customMetadata = { ...identityMetadata, ...repoMetadata, ...customMetadata };
+  customMetadata = { ...contractMetadata, ...identityMetadata, ...repoMetadata, ...customMetadata };
 
   return {
     apiKey,

--- a/src/fixtures/coding-agent-v1/validator.json
+++ b/src/fixtures/coding-agent-v1/validator.json
@@ -1,0 +1,241 @@
+{
+  "schemaVersion": "coding-agent-v1",
+  "description": "Machine-readable contract for LangSmith coding-agent trace metadata. Set on run.extra.metadata. 'requirement' tiers: always = on every run; where_known = required when the runtime exposes the value, omit otherwise; contextual = optional. runTypes: root | llm | tool | subagent | interrupted.",
+  "integrations": ["claude-code", "openai-codex", "deepagents-code", "cursor", "pi"],
+  "runtimeNames": {
+    "claude-code": "Claude Code",
+    "openai-codex": "Codex",
+    "deepagents-code": "Deep Agents Code",
+    "cursor": "Cursor",
+    "pi": "Pi"
+  },
+  "keys": [
+    {
+      "key": "ls_agent_kind",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": ["coding_agent"],
+      "requirement": "always",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "ls_integration",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": ["claude-code", "openai-codex", "deepagents-code", "cursor", "pi"],
+      "requirement": "always",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "ls_agent_runtime",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": ["Claude Code", "Codex", "Deep Agents Code", "Cursor", "Pi"],
+      "requirement": "always",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "thread_id",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "always",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "ls_trace_schema_version",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": ["coding-agent-v1"],
+      "requirement": "always",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "ls_integration_version",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true,
+      "note": "Bundled plugins (cursor, claude-code, pi) must inject at build time via esbuild define; do not require('./package.json')."
+    },
+    {
+      "key": "ls_agent_runtime_version",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "turn_id",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true,
+      "note": "At least one of turn_id / turn_number is required wherever the runtime exposes turns."
+    },
+    {
+      "key": "turn_number",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "integer",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true,
+      "note": "1-based. Pi source is 0-based turnIndex -> emit turnIndex + 1."
+    },
+    {
+      "key": "repository_url",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "repository_provider",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "suggestedValues": ["github", "gitlab", "bitbucket", "other"],
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "repository_name",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "git_branch",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "git_commit_sha",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "cwd",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "where_known",
+      "requiredWhereKnown": true
+    },
+    {
+      "key": "user_id",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "Stable, pseudonymous; preferred over local_username."
+    },
+    {
+      "key": "local_username",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "PII-sensitive, backward-compatible."
+    },
+    {
+      "key": "user_email",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "Provisional / PII. Emit where known, omit otherwise; may be scrapped later."
+    },
+    {
+      "key": "sandbox_type",
+      "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "approval_policy",
+      "appliesTo": ["root", "interrupted"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "Permission mode / policy for the turn. Root + interrupted only."
+    },
+    {
+      "key": "ls_subagent_id",
+      "appliesTo": ["subagent"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false
+    },
+    {
+      "key": "ls_subagent_type",
+      "appliesTo": ["subagent"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "Subagent runs only. Do NOT emit on root runs (e.g. do not copy claude-code's old ls_agent_type='root' here)."
+    },
+    {
+      "key": "ls_tool_name",
+      "appliesTo": ["tool"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "Tool runs only; emit when it differs from the run name. Pass-through native name — no cross-agent taxonomy normalization."
+    }
+  ],
+  "preserveExistingOnModelAndToolRuns": [
+    "ls_provider",
+    "ls_model_name",
+    "ls_invocation_params",
+    "usage_metadata"
+  ],
+  "perIntegrationSources": {
+    "claude-code": {
+      "thread_id": "session_id (hook payload)",
+      "turn_id": "promptId (transcript, native)",
+      "turn_number": "turn_count"
+    },
+    "openai-codex": {
+      "thread_id": "thread_id",
+      "turn_id": "turn_id",
+      "turn_number": "native"
+    },
+    "cursor": {
+      "thread_id": "conversation_id",
+      "turn_id": "generation_id",
+      "turn_number": "turnNum"
+    },
+    "pi": {
+      "thread_id": "ctx.sessionManager.getSessionId()",
+      "turn_id": "none -> use turnIndex as turn_number",
+      "turn_number": "turnIndex (0-based) + 1"
+    },
+    "deepagents-code": {
+      "thread_id": "configurable.thread_id",
+      "turn_id": "add — uuid4 / msg-id per prompt",
+      "turn_number": "add — counter on session_state"
+    }
+  }
+}

--- a/src/fixtures/coding-agent-v1/worked-examples.json
+++ b/src/fixtures/coding-agent-v1/worked-examples.json
@@ -1,0 +1,138 @@
+{
+  "_comment": "Copy-pasteable worked examples of run.extra.metadata for coding-agent-v1. Uses claude-code as the reference integration. Identity block (ls_agent_kind, ls_integration, ls_agent_runtime, thread_id, ls_trace_schema_version) + versions + turn + repo/git/cwd are emitted by ONE shared helper and merged onto EVERY run. Child runs do NOT inherit parent metadata in LangSmith — the helper must stamp each createChild/run.",
+
+  "root": {
+    "ls_agent_kind": "coding_agent",
+    "ls_integration": "claude-code",
+    "ls_agent_runtime": "Claude Code",
+    "thread_id": "sess_7f3c2a9e1b",
+    "ls_trace_schema_version": "coding-agent-v1",
+
+    "ls_integration_version": "0.4.2",
+    "ls_agent_runtime_version": "1.0.38",
+    "turn_id": "prompt_abc123",
+    "turn_number": 3,
+
+    "repository_url": "https://github.com/langchain-ai/langsmith-claude-code-plugins",
+    "repository_provider": "github",
+    "repository_name": "langsmith-claude-code-plugins",
+    "git_branch": "main",
+    "git_commit_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    "cwd": "/Users/dev/langsmith-claude-code-plugins",
+
+    "user_id": "u_9f3ab21c",
+    "local_username": "dev",
+    "user_email": "dev@example.com",
+    "sandbox_type": "none",
+    "approval_policy": "acceptEdits"
+  },
+
+  "llm": {
+    "ls_agent_kind": "coding_agent",
+    "ls_integration": "claude-code",
+    "ls_agent_runtime": "Claude Code",
+    "thread_id": "sess_7f3c2a9e1b",
+    "ls_trace_schema_version": "coding-agent-v1",
+
+    "ls_integration_version": "0.4.2",
+    "ls_agent_runtime_version": "1.0.38",
+    "turn_id": "prompt_abc123",
+    "turn_number": 3,
+
+    "repository_url": "https://github.com/langchain-ai/langsmith-claude-code-plugins",
+    "repository_provider": "github",
+    "repository_name": "langsmith-claude-code-plugins",
+    "git_branch": "main",
+    "git_commit_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    "cwd": "/Users/dev/langsmith-claude-code-plugins",
+
+    "user_id": "u_9f3ab21c",
+    "local_username": "dev",
+    "user_email": "dev@example.com",
+    "sandbox_type": "none",
+
+    "ls_provider": "anthropic",
+    "ls_model_name": "claude-opus-4-8",
+    "ls_invocation_params": { "max_tokens": 8192, "temperature": 1 },
+    "usage_metadata": { "input_tokens": 12873, "output_tokens": 412, "total_tokens": 13285 }
+  },
+
+  "tool": {
+    "ls_agent_kind": "coding_agent",
+    "ls_integration": "claude-code",
+    "ls_agent_runtime": "Claude Code",
+    "thread_id": "sess_7f3c2a9e1b",
+    "ls_trace_schema_version": "coding-agent-v1",
+
+    "ls_integration_version": "0.4.2",
+    "ls_agent_runtime_version": "1.0.38",
+    "turn_id": "prompt_abc123",
+    "turn_number": 3,
+
+    "repository_url": "https://github.com/langchain-ai/langsmith-claude-code-plugins",
+    "repository_provider": "github",
+    "repository_name": "langsmith-claude-code-plugins",
+    "git_branch": "main",
+    "git_commit_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    "cwd": "/Users/dev/langsmith-claude-code-plugins",
+
+    "user_id": "u_9f3ab21c",
+    "local_username": "dev",
+    "user_email": "dev@example.com",
+    "sandbox_type": "none",
+
+    "ls_tool_name": "Bash"
+  },
+
+  "subagent": {
+    "ls_agent_kind": "coding_agent",
+    "ls_integration": "claude-code",
+    "ls_agent_runtime": "Claude Code",
+    "thread_id": "sess_7f3c2a9e1b",
+    "ls_trace_schema_version": "coding-agent-v1",
+
+    "ls_integration_version": "0.4.2",
+    "ls_agent_runtime_version": "1.0.38",
+    "turn_id": "prompt_abc123",
+    "turn_number": 3,
+
+    "repository_url": "https://github.com/langchain-ai/langsmith-claude-code-plugins",
+    "repository_provider": "github",
+    "repository_name": "langsmith-claude-code-plugins",
+    "git_branch": "main",
+    "git_commit_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    "cwd": "/Users/dev/langsmith-claude-code-plugins",
+
+    "user_id": "u_9f3ab21c",
+    "local_username": "dev",
+    "user_email": "dev@example.com",
+    "sandbox_type": "none",
+
+    "ls_subagent_id": "sub_4d8e1f",
+    "ls_subagent_type": "Explore"
+  },
+
+  "interrupted": {
+    "_comment": "Interrupted/cancelled turn. Same base as root, including approval_policy. turn_id/turn_number still emitted.",
+    "ls_agent_kind": "coding_agent",
+    "ls_integration": "claude-code",
+    "ls_agent_runtime": "Claude Code",
+    "thread_id": "sess_7f3c2a9e1b",
+    "ls_trace_schema_version": "coding-agent-v1",
+    "ls_integration_version": "0.4.2",
+    "ls_agent_runtime_version": "1.0.38",
+    "turn_id": "prompt_abc124",
+    "turn_number": 4,
+    "repository_url": "https://github.com/langchain-ai/langsmith-claude-code-plugins",
+    "repository_provider": "github",
+    "repository_name": "langsmith-claude-code-plugins",
+    "git_branch": "main",
+    "git_commit_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    "cwd": "/Users/dev/langsmith-claude-code-plugins",
+    "user_id": "u_9f3ab21c",
+    "local_username": "dev",
+    "user_email": "dev@example.com",
+    "sandbox_type": "none",
+    "approval_policy": "acceptEdits"
+  }
+}

--- a/src/hooks/post-compact.ts
+++ b/src/hooks/post-compact.ts
@@ -12,6 +12,7 @@ import { initTracing, generateDottedOrderSegment } from "../langsmith.js";
 import { loadState, atomicUpdateState, getSessionState } from "../state.js";
 import { initHook } from "../utils/hook-init.js";
 import { readStdin } from "../utils/stdin.js";
+import { codingAgentMetadata } from "../metadata.js";
 
 interface PostCompactHookInput {
   session_id: string;
@@ -25,7 +26,7 @@ interface PostCompactHookInput {
 async function main(): Promise<void> {
   const input: PostCompactHookInput = await readStdin();
 
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config) return;
 
   debug(`PostCompact hook started, session=${input.session_id}, trigger=${input.trigger}`);
@@ -66,12 +67,13 @@ async function main(): Promise<void> {
       dotted_order: dottedOrder,
       ...(parentRunId ? { parent_run_id: parentRunId } : {}),
       extra: {
-        metadata: {
-          thread_id: input.session_id,
-          ls_integration: "claude-code",
-          trigger: input.trigger,
-          ...config.customMetadata,
-        },
+        metadata: codingAgentMetadata({
+          sessionId: input.session_id,
+          base: config.customMetadata,
+          turnNumber: sessionState.current_turn_number,
+          runtimeVersion: sessionState.runtime_version,
+          runSpecific: { trigger: input.trigger },
+        }),
       },
     });
     await runTree.postRun();

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -13,6 +13,7 @@ import { initTracing, generateDottedOrderSegment, flushPendingTraces } from "../
 import { loadState, atomicUpdateState, getSessionState } from "../state.js";
 import { initHook } from "../utils/hook-init.js";
 import { readStdin } from "../utils/stdin.js";
+import { codingAgentMetadata } from "../metadata.js";
 
 interface PostToolUseHookInput {
   session_id: string;
@@ -31,7 +32,7 @@ interface PostToolUseHookInput {
 async function main(): Promise<void> {
   const input: PostToolUseHookInput = await readStdin();
 
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config) return;
 
   // Subagent tool calls are traced by the Stop hook from the transcript.
@@ -93,12 +94,16 @@ async function main(): Promise<void> {
       trace_id: traceId,
       dotted_order: toolDottedOrder,
       extra: {
-        metadata: {
-          thread_id: input.session_id,
-          ls_integration: "claude-code",
-          tool_name: input.tool_name,
-          ...config.customMetadata,
-        },
+        metadata: codingAgentMetadata({
+          sessionId: input.session_id,
+          base: config.customMetadata,
+          // turn_id (promptId) isn't in the PostToolUse payload; turn_number is
+          // sufficient (the contract needs at least one of the two).
+          turnNumber: sessionState.current_turn_number,
+          runtimeVersion: sessionState.runtime_version,
+          toolName: input.tool_name,
+          runName: input.tool_name,
+        }),
       },
     });
     await runTree.postRun();

--- a/src/hooks/pre-compact.ts
+++ b/src/hooks/pre-compact.ts
@@ -23,7 +23,7 @@ interface PreCompactHookInput {
 async function main(): Promise<void> {
   const input: PreCompactHookInput = await readStdin();
 
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config) return;
 
   debug(`PreCompact hook started, session=${input.session_id}, trigger=${input.trigger}`);

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -15,6 +15,7 @@ import { initTracing, closeInterruptedTurn } from "../langsmith.js";
 import { loadState, atomicUpdateState, getSessionState } from "../state.js";
 import { initHook, expandHome } from "../utils/hook-init.js";
 import { readStdin } from "../utils/stdin.js";
+import { readRuntimeVersion } from "../transcript.js";
 
 interface SessionEndHookInput {
   session_id: string;
@@ -27,7 +28,7 @@ interface SessionEndHookInput {
 async function main(): Promise<void> {
   const input: SessionEndHookInput = await readStdin();
 
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config) return;
 
   debug(`SessionEnd hook: session=${input.session_id}, reason=${input.reason}`);
@@ -44,14 +45,21 @@ async function main(): Promise<void> {
 
   debug(`Closing interrupted turn run ${sessionState.current_turn_run_id} on session end`);
 
+  const expandedTranscript = expandHome(input.transcript_path);
+  const runtimeVersion =
+    sessionState.runtime_version ??
+    (expandedTranscript ? readRuntimeVersion(expandedTranscript) : undefined);
+
   try {
     const { lastLine, turnsTraced } = await closeInterruptedTurn({
       sessionId: input.session_id,
       sessionState,
-      transcriptPath: expandHome(input.transcript_path),
+      transcriptPath: expandedTranscript,
       project: config.project,
       stateFilePath: config.stateFilePath,
       customMetadata: config.customMetadata,
+      runtimeVersion,
+      approvalPolicy: sessionState.approval_policy,
     });
 
     await atomicUpdateState(config.stateFilePath, (s) => {

--- a/src/hooks/stop-failure.ts
+++ b/src/hooks/stop-failure.ts
@@ -16,6 +16,7 @@ import { initHook } from "../utils/hook-init.js";
 import { readStdin } from "../utils/stdin.js";
 import { RunTree } from "langsmith";
 import { USER_PROMPT_TURN_NAME } from "../constants.js";
+import { codingAgentMetadata } from "../metadata.js";
 
 interface StopFailureHookInput {
   session_id: string;
@@ -30,7 +31,7 @@ interface StopFailureHookInput {
 async function main(): Promise<void> {
   const input: StopFailureHookInput = await readStdin();
 
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config) return;
 
   debug(`StopFailure hook: session=${input.session_id}, error=${input.error}`);
@@ -62,12 +63,14 @@ async function main(): Promise<void> {
       end_time: new Date().toISOString(),
       error: errorMessage,
       extra: {
-        metadata: {
-          thread_id: input.session_id,
-          ls_integration: "claude-code",
-          turn_number: sessionState.current_turn_number,
-          ...config.customMetadata,
-        },
+        metadata: codingAgentMetadata({
+          sessionId: input.session_id,
+          base: config.customMetadata,
+          turnNumber: sessionState.current_turn_number,
+          runtimeVersion: sessionState.runtime_version,
+          approvalPolicy: sessionState.approval_policy,
+          legacyRole: "root", // DEPRECATED compat alias ls_agent_type="root".
+        }),
       },
     });
     await runTree.patchRun({ excludeInputs: true });

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -7,7 +7,7 @@
  * groups them into turns, and sends traces to LangSmith.
  */
 
-import { readTranscript, groupIntoTurns } from "../transcript.js";
+import { readTranscript, groupIntoTurns, readRuntimeVersion } from "../transcript.js";
 import { log, warn, debug, error } from "../logger.js";
 import {
   loadState,
@@ -22,6 +22,7 @@ import { readStdin } from "../utils/stdin.js";
 import type { StopHookInput } from "../types.js";
 import { RunTree } from "langsmith";
 import { USER_PROMPT_TURN_NAME } from "../constants.js";
+import { codingAgentMetadata } from "../metadata.js";
 
 async function main(): Promise<void> {
   const startTime = Date.now();
@@ -29,7 +30,7 @@ async function main(): Promise<void> {
   // Read hook input from stdin.
   const input: StopHookInput = await readStdin();
 
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config) return;
 
   debug(`Stop hook started, session=${input.session_id}`);
@@ -54,6 +55,10 @@ async function main(): Promise<void> {
   const sessionState = getSessionState(state, input.session_id);
 
   debug(`Last line: ${sessionState.last_line}, turn count: ${sessionState.turn_count}`);
+
+  // CLI version + approval policy: prefer state, fall back to the transcript.
+  const runtimeVersion = sessionState.runtime_version ?? readRuntimeVersion(transcriptPath);
+  const approvalPolicy = sessionState.approval_policy ?? input.permission_mode;
 
   // Wait briefly for the transcript writer to flush. Stop fires as soon as the
   // model finishes generating, but the JSONL file write may still be in flight.
@@ -141,6 +146,8 @@ async function main(): Promise<void> {
         turnNum,
         project: config.project,
         customMetadata: config.customMetadata,
+        runtimeVersion,
+        approvalPolicy,
 
         parentRunId,
         existingTaskRunMap,
@@ -177,13 +184,15 @@ async function main(): Promise<void> {
           messages: [{ role: "assistant", content: input.last_assistant_message }],
         },
         extra: {
-          metadata: {
-            thread_id: input.session_id,
-            ls_integration: "claude-code",
-            ls_agent_type: "root",
-            turn_number: sessionState.current_turn_number,
-            ...config.customMetadata,
-          },
+          metadata: codingAgentMetadata({
+            sessionId: input.session_id,
+            base: config.customMetadata,
+            turnId: turns[turns.length - 1]?.promptId,
+            turnNumber: sessionState.current_turn_number,
+            runtimeVersion,
+            approvalPolicy,
+            legacyRole: "root", // DEPRECATED compat alias ls_agent_type="root".
+          }),
         },
       });
       await runTree.patchRun({ excludeInputs: true });
@@ -212,6 +221,9 @@ async function main(): Promise<void> {
       parentTraceId: freshSession.current_trace_id,
       project: config.project,
       customMetadata: config.customMetadata,
+      runtimeVersion,
+      turnId: turns[turns.length - 1]?.promptId,
+      turnNumber: sessionState.current_turn_number,
     });
   }
 

--- a/src/hooks/subagent-stop.ts
+++ b/src/hooks/subagent-stop.ts
@@ -21,7 +21,7 @@ import type { SubagentStopHookInput } from "../types.js";
 async function main(): Promise<void> {
   const input: SubagentStopHookInput = await readStdin();
 
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config) return;
 
   debug(`SubagentStop hook: agent_id=${input.agent_id}, type=${input.agent_type}`);

--- a/src/hooks/user-prompt-submit.ts
+++ b/src/hooks/user-prompt-submit.ts
@@ -20,10 +20,11 @@ import {
   parseDottedOrder,
 } from "../langsmith.js";
 import { loadState, atomicUpdateState, getSessionState } from "../state.js";
-import { getTranscriptEndLine } from "../transcript.js";
+import { getTranscriptEndLine, readRuntimeVersion } from "../transcript.js";
 import { initHook, expandHome } from "../utils/hook-init.js";
 import { readStdin } from "../utils/stdin.js";
 import { USER_PROMPT_TURN_NAME } from "../constants.js";
+import { codingAgentMetadata } from "../metadata.js";
 
 interface UserPromptSubmitHookInput {
   session_id: string;
@@ -40,7 +41,7 @@ async function main(): Promise<void> {
   const hookStartTime = Date.now();
   const input: UserPromptSubmitHookInput = await readStdin();
 
-  const config = initHook();
+  const config = initHook(input.cwd);
   if (!config) return;
 
   debug(`UserPromptSubmit hook started, session=${input.session_id}`);
@@ -56,6 +57,13 @@ async function main(): Promise<void> {
 
   const state = loadState(config.stateFilePath);
   const sessionState = getSessionState(state, input.session_id);
+
+  // CLI version (ls_agent_runtime_version); best-effort, Stop backfills if empty.
+  const expandedTranscript = expandHome(input.transcript_path);
+  const runtimeVersion =
+    (expandedTranscript ? readRuntimeVersion(expandedTranscript) : undefined) ??
+    sessionState.runtime_version;
+  const approvalPolicy = input.permission_mode;
 
   // If state is fresh (last_line === -1) but the transcript already has content,
   // skip to the end. This avoids replaying thousands of old messages (which would
@@ -85,6 +93,8 @@ async function main(): Promise<void> {
         project: config.project,
         stateFilePath: config.stateFilePath,
         customMetadata: config.customMetadata,
+        runtimeVersion,
+        approvalPolicy,
       });
       interruptedLastLine = lastLine;
       interruptedTurnsTraced = turnsTraced;
@@ -127,7 +137,17 @@ async function main(): Promise<void> {
     trace_id: traceId,
     dotted_order: dottedOrder,
     ...(parentRunId ? { parent_run_id: parentRunId } : {}),
-    ...(config.customMetadata ? { extra: { metadata: { ...config.customMetadata } } } : {}),
+    extra: {
+      metadata: codingAgentMetadata({
+        sessionId: input.session_id,
+        base: config.customMetadata,
+        // turn_id (promptId) isn't known yet; Stop stamps it on completion.
+        turnNumber: turnNum,
+        runtimeVersion,
+        approvalPolicy,
+        legacyRole: "root", // DEPRECATED compat alias ls_agent_type="root".
+      }),
+    },
   });
 
   await runTree.postRun();
@@ -146,6 +166,9 @@ async function main(): Promise<void> {
         current_parent_run_id: parentRunId,
         current_turn_number: turnNum,
         current_turn_start: startTime,
+        // Persisted so the closing hooks can stamp them onto their runs.
+        approval_policy: approvalPolicy,
+        ...(runtimeVersion ? { runtime_version: runtimeVersion } : {}),
         // Advance past the interrupted turn's messages so Stop doesn't re-trace them
         last_line: interruptedLastLine,
         turn_count: ss.turn_count + interruptedTurnsTraced,

--- a/src/langsmith.test.ts
+++ b/src/langsmith.test.ts
@@ -1140,4 +1140,93 @@ describe("traceTurn", () => {
     expect(llmMetadata.ls_provider).toBe("anthropic");
     expect(llmMetadata.ls_model_name).toBe("claude-sonnet-4-5");
   });
+
+  it("stamps coding-agent-v1 keys (turn_id/turn_number/runtime/approval) on every run", async () => {
+    const turn: Turn = {
+      userContent: "Hello",
+      userTimestamp: "2025-01-01T00:00:00Z",
+      promptId: "prompt_xyz",
+      llmCalls: [
+        {
+          content: [{ type: "text", text: "Hi" }],
+          model: "claude-sonnet-4-5",
+          usage: { input_tokens: 10, output_tokens: 5 },
+          startTime: "2025-01-01T00:00:01Z",
+          endTime: "2025-01-01T00:00:02Z",
+          toolCalls: [
+            {
+              tool_use: { type: "tool_use", id: "tu_1", name: "Bash", input: { command: "ls" } },
+              result: { content: "ok", timestamp: "2025-01-01T00:00:03Z" },
+            },
+          ],
+        },
+      ],
+      isComplete: false, // force standalone (root) turn creation + completion
+    };
+
+    await traceTurn({
+      turn,
+      sessionId: "session-123",
+      turnNum: 7,
+      project: "test-project",
+      customMetadata: { ls_integration_version: "0.1.3" },
+      runtimeVersion: "2.1.181",
+      approvalPolicy: "acceptEdits",
+    });
+
+    // Tool run (postRun) — has turn_id, turn_number, runtime version, tool_name compat.
+    const toolPost = allRunTreeInstances.find(
+      (i) => i.params.run_type === "tool" && i.ops.includes("postRun"),
+    )!;
+    const toolMeta = (toolPost.params.extra as Record<string, unknown>).metadata as Record<
+      string,
+      unknown
+    >;
+    expect(toolMeta).toMatchObject({
+      ls_agent_kind: "coding_agent",
+      ls_integration: "claude-code",
+      ls_agent_runtime: "Claude Code",
+      ls_trace_schema_version: "coding-agent-v1",
+      thread_id: "session-123",
+      turn_id: "prompt_xyz",
+      turn_number: 7,
+      ls_agent_runtime_version: "2.1.181",
+      ls_integration_version: "0.1.3",
+      tool_name: "Bash", // DEPRECATED compat alias
+    });
+    expect(toolMeta.ls_tool_name).toBeUndefined(); // equals run name → omitted
+    expect(toolMeta.approval_policy).toBeUndefined(); // tool runs never get approval_policy
+
+    // LLM run (patchRun) — contract keys + preserved model conventions.
+    const llmPatch = allRunTreeInstances.find(
+      (i) => i.params.run_type === "llm" && i.ops.includes("patchRun"),
+    )!;
+    const llmMeta = (llmPatch.params.extra as Record<string, unknown>).metadata as Record<
+      string,
+      unknown
+    >;
+    expect(llmMeta).toMatchObject({
+      turn_id: "prompt_xyz",
+      turn_number: 7,
+      ls_agent_runtime_version: "2.1.181",
+      ls_provider: "anthropic",
+    });
+    expect(llmMeta.ls_agent_type).toBeUndefined(); // not a root/subagent run
+
+    // Standalone (root) turn completion (patchRun) — approval_policy + ls_agent_type compat.
+    const turnPatch = allRunTreeInstances.find(
+      (i) => i.params.name === USER_PROMPT_TURN_NAME && i.ops.includes("patchRun"),
+    )!;
+    const turnMeta = (turnPatch.params.extra as Record<string, unknown>).metadata as Record<
+      string,
+      unknown
+    >;
+    expect(turnMeta).toMatchObject({
+      turn_id: "prompt_xyz",
+      turn_number: 7,
+      approval_policy: "acceptEdits",
+      ls_agent_type: "root", // DEPRECATED compat alias
+    });
+    expect(turnMeta.ls_subagent_type).toBeUndefined(); // never on root
+  });
 });

--- a/src/langsmith.ts
+++ b/src/langsmith.ts
@@ -12,6 +12,7 @@ import { readTranscript, groupIntoTurns } from "./transcript.js";
 import { loadState, getSessionState } from "./state.js";
 import * as logger from "./logger.js";
 import { ASSISTANT_RUN_NAME, USER_PROMPT_TURN_NAME } from "./constants.js";
+import { codingAgentMetadata } from "./metadata.js";
 
 // ─── Client setup ───────────────────────────────────────────────────────────
 
@@ -149,8 +150,12 @@ export interface TraceTurnOptions {
   tracedToolUseIds?: Set<string>;
   traceId?: string;
   parentDottedOrder?: string;
-  /** Custom metadata to attach to root turn runs. */
+  /** Base coding-agent-v1 metadata (config base + user env metadata) merged onto every run. */
   customMetadata?: Record<string, unknown>;
+  /** Claude Code CLI version → `ls_agent_runtime_version`. */
+  runtimeVersion?: string;
+  /** Permission mode → `approval_policy` (stamped on root/standalone turn runs only). */
+  approvalPolicy?: string;
 }
 
 /**
@@ -171,7 +176,12 @@ export async function traceTurn(
     traceId: providedTraceId,
     parentDottedOrder: providedParentDottedOrder,
     customMetadata,
+    runtimeVersion,
+    approvalPolicy,
   } = options;
+
+  // turn_id for every run created for this turn (transcript promptId).
+  const turnId = turn.promptId;
 
   let traceId = providedTraceId;
   let parentDottedOrder = providedParentDottedOrder;
@@ -221,7 +231,17 @@ export async function traceTurn(
       start_time: turn.userTimestamp,
       trace_id: traceId,
       dotted_order: parentDottedOrder,
-      ...(customMetadata ? { extra: { metadata: { ...customMetadata } } } : {}),
+      extra: {
+        metadata: codingAgentMetadata({
+          sessionId,
+          base: customMetadata,
+          turnId,
+          turnNumber: turnNum,
+          runtimeVersion,
+          approvalPolicy,
+          legacyRole: "root", // DEPRECATED compat alias ls_agent_type="root".
+        }),
+      },
     });
     await runTree.postRun();
   }
@@ -308,7 +328,15 @@ export async function traceTurn(
         trace_id: traceId,
         dotted_order: toolDottedOrder,
         extra: {
-          metadata: { thread_id: sessionId, ls_integration: "claude-code", ...customMetadata },
+          metadata: codingAgentMetadata({
+            sessionId,
+            base: customMetadata,
+            turnId,
+            turnNumber: turnNum,
+            runtimeVersion,
+            toolName: toolCall.tool_use.name,
+            runName: toolCall.tool_use.name,
+          }),
         },
       });
       await runTree.postRun();
@@ -345,18 +373,22 @@ export async function traceTurn(
         messages: [{ role: "assistant", content: assistantContent }],
       },
       extra: {
-        metadata: {
-          thread_id: sessionId,
-          ls_integration: "claude-code",
-          ls_provider: "anthropic",
-          ls_model_name: llmCall.model,
-          ls_invocation_params: {
-            model: llmCall.model,
+        metadata: codingAgentMetadata({
+          sessionId,
+          base: customMetadata,
+          turnId,
+          turnNumber: turnNum,
+          runtimeVersion,
+          runSpecific: {
+            ls_provider: "anthropic",
+            ls_model_name: llmCall.model,
+            ls_invocation_params: {
+              model: llmCall.model,
+            },
+            usage_metadata: buildUsageMetadata(llmCall.usage),
+            ...(llmCall.synthetic ? { synthetic: true } : {}),
           },
-          usage_metadata: buildUsageMetadata(llmCall.usage),
-          ...(llmCall.synthetic ? { synthetic: true } : {}),
-          ...customMetadata,
-        },
+        }),
       },
     });
 
@@ -395,12 +427,15 @@ export async function traceTurn(
       outputs: { messages: turnOutputs },
       error: error,
       extra: {
-        metadata: {
-          thread_id: sessionId,
-          ls_integration: "claude-code",
-          turn_number: turnNum,
-          ...customMetadata,
-        },
+        metadata: codingAgentMetadata({
+          sessionId,
+          base: customMetadata,
+          turnId,
+          turnNumber: turnNum,
+          runtimeVersion,
+          approvalPolicy,
+          legacyRole: "root", // DEPRECATED compat alias ls_agent_type="root".
+        }),
       },
     });
 
@@ -435,15 +470,30 @@ export async function closeInterruptedTurn(options: {
   project: string;
   stateFilePath: string;
   customMetadata?: Record<string, unknown>;
+  /** Claude Code CLI version → `ls_agent_runtime_version`. */
+  runtimeVersion?: string;
+  /** Permission mode → `approval_policy` for the interrupted root turn. */
+  approvalPolicy?: string;
 }): Promise<{ lastLine: number; turnsTraced: number }> {
-  const { sessionId, sessionState, transcriptPath, project, stateFilePath, customMetadata } =
-    options;
+  const {
+    sessionId,
+    sessionState,
+    transcriptPath,
+    project,
+    stateFilePath,
+    customMetadata,
+    runtimeVersion,
+    approvalPolicy,
+  } = options;
   if (!client && !replicas)
     throw new Error("LangSmith client not initialized — call initTracing() first");
 
   let lastLine = sessionState.last_line;
   let turnsTraced = 0;
   let taskRunMap = sessionState.task_run_map ?? {};
+  // Parent turn markers to propagate onto subagent runs.
+  let turnId: string | undefined;
+  const turnNumber = sessionState.current_turn_number;
 
   // Trace LLM calls from the transcript if we have a path.
   if (transcriptPath) {
@@ -455,6 +505,7 @@ export async function closeInterruptedTurn(options: {
       if (messages.length > 0) {
         const turns = groupIntoTurns(messages);
         if (turns.length > 0) {
+          turnId = turns[turns.length - 1].promptId;
           await traceTurn({
             turn: turns[turns.length - 1],
             sessionId,
@@ -465,6 +516,9 @@ export async function closeInterruptedTurn(options: {
             tracedToolUseIds: new Set(sessionState.traced_tool_use_ids ?? []),
             traceId: sessionState.current_trace_id,
             parentDottedOrder: sessionState.current_dotted_order,
+            customMetadata,
+            runtimeVersion,
+            approvalPolicy,
           });
           lastLine = newLastLine;
           turnsTraced = 1;
@@ -491,6 +545,9 @@ export async function closeInterruptedTurn(options: {
         parentTraceId: sessionState.current_trace_id,
         project,
         customMetadata,
+        runtimeVersion,
+        turnId,
+        turnNumber,
       });
     } catch (err) {
       logger.error(`Failed to trace pending subagents on interrupt: ${err}`);
@@ -511,12 +568,14 @@ export async function closeInterruptedTurn(options: {
     end_time: new Date().toISOString(),
     error: "User interrupt",
     extra: {
-      metadata: {
-        thread_id: sessionId,
-        ls_integration: "claude-code",
-        turn_number: sessionState.current_turn_number,
-        ...customMetadata,
-      },
+      metadata: codingAgentMetadata({
+        sessionId,
+        base: customMetadata,
+        turnNumber: sessionState.current_turn_number,
+        runtimeVersion,
+        approvalPolicy,
+        legacyRole: "root", // DEPRECATED compat alias ls_agent_type="root".
+      }),
     },
   });
 
@@ -555,9 +614,24 @@ export async function tracePendingSubagents(options: {
   parentTraceId: string | undefined;
   project: string;
   customMetadata?: Record<string, unknown>;
+  /** Claude Code CLI version → `ls_agent_runtime_version`. */
+  runtimeVersion?: string;
+  /** Enclosing turn's promptId → `turn_id` on the subagent + Agent tool runs. */
+  turnId?: string;
+  /** Enclosing turn's 1-based index → `turn_number` (not re-incremented). */
+  turnNumber?: number;
 }): Promise<void> {
-  const { sessionId, pendingSubagents, taskRunMap, parentTraceId, project, customMetadata } =
-    options;
+  const {
+    sessionId,
+    pendingSubagents,
+    taskRunMap,
+    parentTraceId,
+    project,
+    customMetadata,
+    runtimeVersion,
+    turnId,
+    turnNumber,
+  } = options;
 
   if (!client && !replicas) {
     throw new Error("LangSmith client not initialized — call initTracing() first");
@@ -619,14 +693,20 @@ export async function tracePendingSubagents(options: {
           trace_id: deferred.trace_id as string,
           dotted_order: agentToolDottedOrder,
           extra: {
-            metadata: {
-              thread_id: sessionId,
-              ls_integration: "claude-code",
-              tool_name: "Agent",
-              agent_type: toolName,
-              agent_id: subagent.agent_id,
-              ...customMetadata,
-            },
+            metadata: codingAgentMetadata({
+              sessionId,
+              base: customMetadata,
+              runtimeVersion,
+              turnId,
+              turnNumber,
+              // run_type "tool" (run name "Agent", native tool "Task").
+              toolName: "Task",
+              runName: "Agent",
+              runSpecific: {
+                agent_type: toolName, // DEPRECATED compat alias.
+                agent_id: subagent.agent_id, // DEPRECATED compat alias.
+              },
+            }),
           },
         });
         await runTree.postRun();
@@ -652,14 +732,16 @@ export async function tracePendingSubagents(options: {
         trace_id: parentTraceId,
         dotted_order: subagentChainDottedOrder,
         extra: {
-          metadata: {
-            thread_id: sessionId,
-            ls_integration: "claude-code",
-            ls_agent_type: "subagent",
-            agent_type: toolName,
-            agent_id: subagent.agent_id,
-            ...customMetadata,
-          },
+          metadata: codingAgentMetadata({
+            sessionId,
+            base: customMetadata,
+            runtimeVersion,
+            turnId,
+            turnNumber,
+            legacyRole: "subagent", // DEPRECATED compat alias.
+            subagentId: subagent.agent_id, // → ls_subagent_id (+ agent_id alias).
+            subagentType: toolName, // → ls_subagent_type (+ agent_type alias).
+          }),
         },
       });
       await runTree.postRun();
@@ -675,6 +757,7 @@ export async function tracePendingSubagents(options: {
           traceId: parentTraceId,
           parentDottedOrder: subagentChainDottedOrder,
           customMetadata,
+          runtimeVersion,
         });
       }
 

--- a/src/metadata.test.ts
+++ b/src/metadata.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Contract test: loads validator.json and asserts the helper emits the required
+ * keys (correct types + allowed values) for each run type.
+ */
+
+import { describe, it, expect } from "vitest";
+import { codingAgentMetadata } from "./metadata.js";
+import validator from "./fixtures/coding-agent-v1/validator.json" with { type: "json" };
+
+type RunType = "root" | "llm" | "tool" | "subagent" | "interrupted";
+
+interface ValidatorKey {
+  key: string;
+  appliesTo: RunType[];
+  type: "string" | "integer";
+  allowedValues: string[] | null;
+  requirement: "always" | "where_known" | "contextual";
+  requiredWhereKnown: boolean;
+}
+
+const KEYS = validator.keys as ValidatorKey[];
+
+// Static base metadata as produced by config.ts (config-sourced contract keys
+// + user attribution). The helper merges this onto every run.
+const BASE = {
+  ls_integration_version: "0.1.3",
+  repository_url: "https://github.com/langchain-ai/langsmith-claude-code-plugins",
+  repository_provider: "github",
+  repository_name: "langchain-ai/langsmith-claude-code-plugins",
+  git_branch: "main",
+  git_commit_sha: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+  cwd: "/Users/dev/langsmith-claude-code-plugins",
+  user_id: "u_9f3ab21c",
+  local_username: "dev",
+  anthropic_user_id: "u_9f3ab21c",
+};
+
+const COMMON = {
+  sessionId: "sess_7f3c2a9e1b",
+  base: BASE,
+  turnId: "prompt_abc123",
+  turnNumber: 3,
+  runtimeVersion: "2.1.181",
+} as const;
+
+// One representative metadata object per run type, built via the shared helper.
+const RUNS: Record<RunType, Record<string, unknown>> = {
+  root: codingAgentMetadata({ ...COMMON, approvalPolicy: "acceptEdits", legacyRole: "root" }),
+  llm: codingAgentMetadata({
+    ...COMMON,
+    runSpecific: {
+      ls_provider: "anthropic",
+      ls_model_name: "claude-opus-4-8",
+      ls_invocation_params: { max_tokens: 8192, temperature: 1 },
+      usage_metadata: { input_tokens: 12873, output_tokens: 412, total_tokens: 13285 },
+    },
+  }),
+  tool: codingAgentMetadata({ ...COMMON, toolName: "Bash", runName: "Bash" }),
+  subagent: codingAgentMetadata({
+    ...COMMON,
+    legacyRole: "subagent",
+    subagentId: "sub_4d8e1f",
+    subagentType: "Explore",
+  }),
+  interrupted: codingAgentMetadata({
+    ...COMMON,
+    approvalPolicy: "acceptEdits",
+    legacyRole: "root",
+  }),
+};
+
+function checkType(value: unknown, type: "string" | "integer"): boolean {
+  return type === "integer" ? Number.isInteger(value) : typeof value === "string";
+}
+
+describe("coding-agent-v1 contract", () => {
+  const runTypes = Object.keys(RUNS) as RunType[];
+
+  it("validator covers the expected run types", () => {
+    expect(new Set(validator.integrations)).toContain("claude-code");
+    expect(validator.schemaVersion).toBe("coding-agent-v1");
+  });
+
+  describe.each(runTypes)("%s run", (runType) => {
+    const meta = RUNS[runType];
+
+    // Every "always" key must be present with correct type + allowed value.
+    const alwaysKeys = KEYS.filter(
+      (k) => k.requirement === "always" && k.appliesTo.includes(runType),
+    );
+    it.each(alwaysKeys.map((k) => [k.key, k] as const))(
+      "has required key %s",
+      (_name, entry) => {
+        expect(meta[entry.key], `${entry.key} missing`).toBeDefined();
+        expect(checkType(meta[entry.key], entry.type), `${entry.key} wrong type`).toBe(true);
+        if (entry.allowedValues) {
+          expect(entry.allowedValues).toContain(meta[entry.key]);
+        }
+      },
+    );
+
+    // "where_known" keys: every source is provided, so all must be present.
+    const whereKnownKeys = KEYS.filter(
+      (k) => k.requirement === "where_known" && k.appliesTo.includes(runType),
+    );
+    it.each(whereKnownKeys.map((k) => [k.key, k] as const))(
+      "has where-known key %s",
+      (_name, entry) => {
+        expect(meta[entry.key], `${entry.key} missing`).toBeDefined();
+        expect(checkType(meta[entry.key], entry.type), `${entry.key} wrong type`).toBe(true);
+      },
+    );
+
+    // Any present contract key must be valid and apply to this run type.
+    it("emits no key outside its appliesTo, and all present keys are valid", () => {
+      for (const entry of KEYS) {
+        if (meta[entry.key] === undefined) continue;
+        expect(entry.appliesTo, `${entry.key} should not appear on ${runType}`).toContain(runType);
+        expect(checkType(meta[entry.key], entry.type), `${entry.key} wrong type`).toBe(true);
+        if (entry.allowedValues) {
+          expect(entry.allowedValues).toContain(meta[entry.key]);
+        }
+      }
+    });
+  });
+
+  // ─── Identity literals ──────────────────────────────────────────────────────
+
+  it.each(Object.keys(RUNS) as RunType[])("%s run carries the frozen identity block", (rt) => {
+    const meta = RUNS[rt];
+    expect(meta.ls_agent_kind).toBe("coding_agent");
+    expect(meta.ls_integration).toBe("claude-code");
+    expect(meta.ls_agent_runtime).toBe("Claude Code");
+    expect(meta.ls_trace_schema_version).toBe("coding-agent-v1");
+    expect(meta.thread_id).toBe("sess_7f3c2a9e1b");
+  });
+
+  // ─── ls_subagent_type is subagent-only and never "root" ──────────────────────
+
+  it("emits ls_subagent_type / ls_subagent_id only on subagent runs", () => {
+    expect(RUNS.subagent.ls_subagent_type).toBe("Explore");
+    expect(RUNS.subagent.ls_subagent_id).toBe("sub_4d8e1f");
+    for (const rt of ["root", "llm", "tool", "interrupted"] as RunType[]) {
+      expect(RUNS[rt].ls_subagent_type, `ls_subagent_type leaked onto ${rt}`).toBeUndefined();
+      expect(RUNS[rt].ls_subagent_id, `ls_subagent_id leaked onto ${rt}`).toBeUndefined();
+    }
+  });
+
+  it("never emits ls_subagent_type='root' (uses ls_agent_type compat alias instead)", () => {
+    expect(RUNS.root.ls_subagent_type).toBeUndefined();
+    expect(RUNS.root.ls_agent_type).toBe("root"); // DEPRECATED compat alias
+    expect(RUNS.subagent.ls_agent_type).toBe("subagent"); // DEPRECATED compat alias
+  });
+
+  // ─── Turn markers propagate to subagent + Agent-tool runs ────────────────────
+
+  it("propagates the parent turn's turn_id + turn_number onto the subagent run", () => {
+    expect(RUNS.subagent.turn_id).toBe("prompt_abc123");
+    expect(RUNS.subagent.turn_number).toBe(3);
+  });
+
+  it("propagates turn markers + ls_tool_name='Task' onto the Agent tool run", () => {
+    // Mirrors tracePendingSubagents: run name "Agent", native tool "Task".
+    const agentTool = codingAgentMetadata({
+      ...COMMON,
+      toolName: "Task",
+      runName: "Agent",
+      runSpecific: { agent_type: "Explore", agent_id: "sub_4d8e1f" },
+    });
+    expect(agentTool.turn_id).toBe("prompt_abc123");
+    expect(agentTool.turn_number).toBe(3);
+    expect(agentTool.ls_tool_name).toBe("Task"); // name "Agent" ≠ tool "Task"
+    expect(agentTool.tool_name).toBe("Task"); // DEPRECATED compat alias
+    expect(agentTool.ls_subagent_type).toBeUndefined(); // subagent-only
+    expect(agentTool.ls_subagent_id).toBeUndefined();
+  });
+
+  // ─── approval_policy is root + interrupted only ──────────────────────────────
+
+  it("emits approval_policy only on root + interrupted runs", () => {
+    expect(RUNS.root.approval_policy).toBe("acceptEdits");
+    expect(RUNS.interrupted.approval_policy).toBe("acceptEdits");
+    expect(RUNS.llm.approval_policy).toBeUndefined();
+    expect(RUNS.tool.approval_policy).toBeUndefined();
+    expect(RUNS.subagent.approval_policy).toBeUndefined();
+  });
+
+  // ─── ls_tool_name only when it differs from the run name ─────────────────────
+
+  it("omits ls_tool_name when tool name equals run name, keeps tool_name compat alias", () => {
+    expect(RUNS.tool.tool_name).toBe("Bash"); // DEPRECATED compat alias, always kept
+    expect(RUNS.tool.ls_tool_name).toBeUndefined(); // equal to run name → omitted
+  });
+
+  it("emits ls_tool_name when tool name differs from run name", () => {
+    const meta = codingAgentMetadata({ ...COMMON, toolName: "Bash", runName: "Agent" });
+    expect(meta.ls_tool_name).toBe("Bash");
+    expect(meta.tool_name).toBe("Bash");
+  });
+
+  // ─── Model run keeps existing conventions unchanged ──────────────────────────
+
+  it("preserves ls_provider/ls_model_name/usage_metadata on model runs", () => {
+    for (const key of validator.preserveExistingOnModelAndToolRuns) {
+      if (key === "usage_metadata" || key.startsWith("ls_")) {
+        // present on the llm fixture
+      }
+    }
+    expect(RUNS.llm.ls_provider).toBe("anthropic");
+    expect(RUNS.llm.ls_model_name).toBe("claude-opus-4-8");
+    expect(RUNS.llm.usage_metadata).toMatchObject({ total_tokens: 13285 });
+  });
+
+  // ─── Unknown values are omitted, never null/empty ────────────────────────────
+
+  it("omits keys whose source is unknown (no null/empty values)", () => {
+    const sparse = codingAgentMetadata({ sessionId: "s1" });
+    expect(sparse.turn_id).toBeUndefined();
+    expect(sparse.turn_number).toBeUndefined();
+    expect(sparse.ls_agent_runtime_version).toBeUndefined();
+    expect(sparse.approval_policy).toBeUndefined();
+    for (const [, v] of Object.entries(sparse)) {
+      expect(v === null || v === "").toBe(false);
+    }
+    // Identity literals are still present even with no context.
+    expect(sparse.ls_agent_kind).toBe("coding_agent");
+    expect(sparse.thread_id).toBe("s1");
+  });
+
+  // ─── User-supplied env metadata wins on collision ────────────────────────────
+
+  it("lets user-supplied base metadata override contract keys", () => {
+    const meta = codingAgentMetadata({
+      sessionId: "s1",
+      base: { thread_id: "override", ls_integration: "custom" },
+    });
+    expect(meta.thread_id).toBe("override");
+    expect(meta.ls_integration).toBe("custom");
+  });
+});

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,0 +1,115 @@
+/**
+ * coding-agent-v1 trace metadata contract. One shared helper, stamped on every
+ * run (children don't inherit parent `extra.metadata`). See validator.json.
+ */
+
+// ─── Frozen literals (identity block) ────────────────────────────────────────
+
+export const LS_AGENT_KIND = "coding_agent";
+export const LS_INTEGRATION = "claude-code";
+export const LS_AGENT_RUNTIME = "Claude Code";
+export const LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
+
+// ─── Helper input ─────────────────────────────────────────────────────────────
+
+export interface CodingAgentMetadataOptions {
+  /** Stable conversation/session id → `thread_id`. Required on every run. */
+  sessionId: string;
+
+  /** Static config base + user env metadata. Spread LAST so user keys win. */
+  base?: Record<string, unknown>;
+
+  /** Per-turn id (`turn_id`) — Claude Code transcript `promptId`. */
+  turnId?: string;
+  /** 1-based turn index (`turn_number`). */
+  turnNumber?: number;
+  /** Claude Code CLI version (`ls_agent_runtime_version`), from transcript `version`. */
+  runtimeVersion?: string;
+
+  /** Permission mode for the turn (`approval_policy`). Root + interrupted only. */
+  approvalPolicy?: string;
+
+  /** DEPRECATED `ls_agent_type` compat alias. Distinct from `ls_subagent_type`. */
+  legacyRole?: "root" | "subagent";
+
+  /** Subagent identity (subagent runs only) → `ls_subagent_id` / `ls_subagent_type`. */
+  subagentId?: string;
+  subagentType?: string;
+
+  /** Native tool name (tool runs). Emits `ls_tool_name` only when it differs from `runName`. */
+  toolName?: string;
+  /** Run `name` used to decide whether `ls_tool_name` is needed. */
+  runName?: string;
+
+  /** Preserved run-type keys (ls_provider, usage_metadata, …) and compat aliases. */
+  runSpecific?: Record<string, unknown>;
+}
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build the metadata for one run. Merge order (later wins): identity → dynamic
+ * → runSpecific → base. Unknown values are omitted (never null/empty).
+ */
+export function codingAgentMetadata(
+  opts: CodingAgentMetadataOptions,
+): Record<string, unknown> {
+  const {
+    sessionId,
+    base,
+    turnId,
+    turnNumber,
+    runtimeVersion,
+    approvalPolicy,
+    legacyRole,
+    subagentId,
+    subagentType,
+    toolName,
+    runName,
+    runSpecific,
+  } = opts;
+
+  const meta: Record<string, unknown> = {
+    // Identity & grouping — always present.
+    ls_agent_kind: LS_AGENT_KIND,
+    ls_integration: LS_INTEGRATION,
+    ls_agent_runtime: LS_AGENT_RUNTIME,
+    ls_trace_schema_version: LS_TRACE_SCHEMA_VERSION,
+    thread_id: sessionId,
+  };
+
+  // Turn — emit whichever is known (at least one required where turns exist).
+  if (turnId) meta.turn_id = turnId;
+  if (typeof turnNumber === "number") meta.turn_number = turnNumber;
+
+  // Versions — runtime (CLI) version where known. Integration version lives in `base`.
+  if (runtimeVersion) meta.ls_agent_runtime_version = runtimeVersion;
+
+  // Approval policy — root + interrupted turns only.
+  if (approvalPolicy) meta.approval_policy = approvalPolicy;
+
+  // DEPRECATED compat alias for the old root/subagent role marker.
+  if (legacyRole) meta.ls_agent_type = legacyRole;
+
+  // Subagent identity (subagent runs only).
+  if (subagentId) {
+    meta.ls_subagent_id = subagentId;
+    meta.agent_id = subagentId; // DEPRECATED compat alias.
+  }
+  if (subagentType) {
+    meta.ls_subagent_type = subagentType;
+    meta.agent_type = subagentType; // DEPRECATED compat alias.
+  }
+
+  // Tool runs: ls_tool_name only when the native name differs from the run name.
+  if (toolName) {
+    meta.tool_name = toolName; // DEPRECATED compat alias.
+    if (runName && toolName !== runName) meta.ls_tool_name = toolName;
+  }
+
+  return {
+    ...meta,
+    ...runSpecific,
+    ...base,
+  };
+}

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -162,6 +162,44 @@ export function getTranscriptEndLine(filePath: string): number {
   }
 }
 
+/**
+ * Read the Claude Code CLI `version` from a transcript tail (→
+ * `ls_agent_runtime_version`). Returns `undefined` if not found.
+ */
+export function readRuntimeVersion(filePath: string): string | undefined {
+  let fd: number | undefined;
+  try {
+    const size = statSync(filePath).size;
+    if (size === 0) return undefined;
+
+    const window = 64 * 1024; // tail bytes — enough to contain at least one full line
+    const start = Math.max(0, size - window);
+    const len = size - start;
+    const buf = Buffer.alloc(len);
+    fd = openSync(filePath, "r");
+    readSync(fd, buf, 0, len, start);
+
+    const text = buf.toString("utf-8");
+    const lines = text.split("\n").filter((l) => l.trim() !== "");
+    // Scan from the end for the most recent line carrying a version.
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const parsed = JSON.parse(lines[i]) as { version?: unknown };
+        if (typeof parsed.version === "string" && parsed.version.length > 0) {
+          return parsed.version;
+        }
+      } catch {
+        // Partial/leading line from the tail window or malformed — skip.
+      }
+    }
+  } catch {
+    // File missing or unreadable — non-fatal.
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+  return undefined;
+}
+
 /** Check if a message is a human user prompt (string content, or array content without tool_result blocks — e.g. images). */
 export function isHumanMessage(msg: TranscriptMessage): msg is UserMessage {
   if (msg.type !== "user") return false;
@@ -346,6 +384,7 @@ export function groupIntoTurns(messages: TranscriptMessage[]): Turn[] {
       userTimestamp: currentUser.timestamp,
       llmCalls,
       isComplete,
+      promptId: currentUser.promptId,
     });
   }
 

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -3,7 +3,7 @@
  * messages into Turns (user prompt → LLM calls → tool results).
  */
 
-import { readFileSync, statSync, openSync, readSync, closeSync } from "node:fs";
+import { readFileSync, statSync, fstatSync, openSync, readSync, closeSync } from "node:fs";
 import type {
   TranscriptMessage,
   AssistantMessage,
@@ -169,14 +169,15 @@ export function getTranscriptEndLine(filePath: string): number {
 export function readRuntimeVersion(filePath: string): string | undefined {
   let fd: number | undefined;
   try {
-    const size = statSync(filePath).size;
+    // Open first, then fstat the descriptor (avoids a stat/open TOCTOU race).
+    fd = openSync(filePath, "r");
+    const size = fstatSync(fd).size;
     if (size === 0) return undefined;
 
     const window = 64 * 1024; // tail bytes — enough to contain at least one full line
     const start = Math.max(0, size - window);
     const len = size - start;
     const buf = Buffer.alloc(len);
-    fd = openSync(filePath, "r");
     readSync(fd, buf, 0, len, start);
 
     const text = buf.toString("utf-8");

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,8 @@ export interface Turn {
   llmCalls: LLMCall[];
   /** Whether the turn is complete (has stop_reason: "end_turn"). If false, the assistant is still responding. */
   isComplete: boolean;
+  /** Claude Code prompt id for this turn → coding-agent-v1 `turn_id`. */
+  promptId?: string;
 }
 
 // ─── Tracing State ─────────────────────────────────────────────────────────
@@ -174,6 +176,10 @@ export interface SessionState {
   current_turn_number?: number;
   /** Current turn start time (ISO string) for duration calculation */
   current_turn_start?: string;
+  /** Permission mode for the current turn → coding-agent-v1 `approval_policy` (root/interrupted). */
+  approval_policy?: string;
+  /** Claude Code CLI version → coding-agent-v1 `ls_agent_runtime_version`. */
+  runtime_version?: string;
   /** Wall-clock time (ms) when the last tool finished, set by PostToolUse */
   last_tool_end_time?: number;
   /** Maps tool_use_id -> wall-clock start time (ms), set by PreToolUse */

--- a/src/utils/hook-init.ts
+++ b/src/utils/hook-init.ts
@@ -8,9 +8,12 @@ import { initLogger, error } from "../logger.js";
 /**
  * Standard hook startup: load config, init logger, check kill-switch and API key.
  * Returns the Config if tracing should proceed, null if the hook should exit early.
+ *
+ * Pass the hook input's `cwd` so repo/git metadata and the `cwd` contract key
+ * reflect the working directory Claude Code is operating in.
  */
-export function initHook(): Config | null {
-  const config = loadConfig();
+export function initHook(cwd?: string): Config | null {
+  const config = loadConfig({ cwd });
   initLogger(config.debug);
 
   if (process.env.TRACE_TO_LANGSMITH?.toLowerCase() !== "true") {


### PR DESCRIPTION
Implements the [coding-agent-v1](https://app.notion.com/p/Coding-Agent-Trace-Metadata-Standard-coding-agent-v1-37d808527b178163a29ef4b617b6dfee) contract so that traces are identifiable, groupable, and attributable with the same stable keys as the other coding-agent integrations.

### Changes
- **`src/metadata.ts`** — single `codingAgentMetadata()` helper returning the base contract object (identity literals + where-known keys + compat aliases), omitting any key whose value is unknown.
- **Stamped onto every run site** — root, LLM, tool, subagent, and interrupted/cancelled turns (child runs don't inherit `extra.metadata`, so each is stamped).
- **New keys**: `ls_agent_kind`, `ls_agent_runtime`, `ls_agent_runtime_version`, `ls_integration_version`, `ls_trace_schema_version`, `turn_id`, `repository_url`, `git_branch`, `git_commit_sha`, `cwd`, `user_id`, `approval_policy`.
- **Renamed keys**: `ls_agent_type`→`ls_subagent_type` (subagent-only), `agent_id`→`ls_subagent_id`, `tool_name`→`ls_tool_name` (when run name ≠ native tool name). Old keys retained + marked deprecated.
- **Build-time version injection** (`esbuild.config.mjs` defines `__LS_INTEGRATION_VERSION__` from package.json) — bundle has no runtime package.json.
- **Contract test** (`src/metadata.test.ts`) loads `validator.json` and asserts required keys, types, allowed values, and negative rules per run type.

### Testing
Verified on real traces: loaded a frozen `validator.json` file tailored to schema, and asserted keys, types, values, and rules per run type.

### Notes
- `sandbox_type` and `user_email` omitted where Claude Code exposes no reliable signal.
- Existing model/tool-run keys (`ls_provider`, `ls_model_name`, `ls_invocation_params`, `usage_metadata`) unchanged.