### PR TITLE
fix: deterministic LLM run IDs to prevent duplicate assistant runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Codex to LangSmith Tracing Project
+
+## Project Overview
+
+This project sets up tracing of Codex conversations to LangSmith.
+
+## How It Works
+
+- A "Stop" hook is configured in `.Codex/settings.local.json` that runs each time Codex responds
+- The hook reads Codex's generated conversation transcripts
+- Messages in the transcript are converted into LangSmith runs and sent to the configured LangSmith project
+
+## Commands
+
+### Fetch Traces
+
+Use the langsmith-fetch command to retrieve traces from the LangSmith project when you want to debug. Do this proactivley to make sure your changes are correct:
+
+Get the last trace:
+
+```bash
+langsmith-fetch traces --project-uuid 16e20536-e4d7-4390-8fcf-1d49cb47f4c2 --format json
+```
+
+Get the last N traces:
+
+```bash
+langsmith-fetch traces --project-uuid 16e20536-e4d7-4390-8fcf-1d49cb47f4c2 --format json --limit 5
+```
+
+## Project Configuration
+
+- LangSmith Project UUID: `16e20536-e4d7-4390-8fcf-1d49cb47f4c2`
+- Hook configuration is in `.Codex/settings.local.json`

--- a/bundle/post-compact.js
+++ b/bundle/post-compact.js
@@ -11952,6 +11952,9 @@ function debug(message) {
   }
 }
 
+// dist/langsmith.js
+import { createHash } from "node:crypto";
+
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/anonymizer/index.js
 function extractStringNodes(data, options) {
   const parsedOptions = { ...options, maxDepth: options.maxDepth ?? 10 };

--- a/bundle/post-tool-use.js
+++ b/bundle/post-tool-use.js
@@ -11952,6 +11952,9 @@ function debug(message) {
   }
 }
 
+// dist/langsmith.js
+import { createHash } from "node:crypto";
+
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/anonymizer/index.js
 function extractStringNodes(data, options) {
   const parsedOptions = { ...options, maxDepth: options.maxDepth ?? 10 };

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -633,6 +633,9 @@ function debug(message) {
   }
 }
 
+// dist/langsmith.js
+import { createHash } from "node:crypto";
+
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/utils/uuid/src/regex.js
 var regex_default = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/i;
 
@@ -12301,6 +12304,7 @@ function mergeAssistantChunks(chunks) {
   const allBlocks = chunks.flatMap((c) => c.message.content);
   const merged = mergeAdjacentTextBlocks(allBlocks);
   return {
+    id: first.message.id,
     content: merged,
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage,
@@ -12375,6 +12379,7 @@ function groupIntoTurns(messages) {
         };
       });
       llmCalls.push({
+        messageId: merged.id,
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
@@ -12559,6 +12564,13 @@ function generateDottedOrderSegment(time, runId) {
   const stripped = isoWithMicroseconds.replace(/[-:.]/g, "");
   return stripped + runId;
 }
+function deterministicUuid(key) {
+  const h = createHash("sha256").update(key).digest("hex").slice(0, 32).split("");
+  h[12] = "8";
+  h[16] = (parseInt(h[16], 16) & 3 | 8).toString(16);
+  const s = h.join("");
+  return `${s.slice(0, 8)}-${s.slice(8, 12)}-${s.slice(12, 16)}-${s.slice(16, 20)}-${s.slice(20, 32)}`;
+}
 function formatContent(blocks) {
   return blocks.map((block) => {
     switch (block.type) {
@@ -12648,7 +12660,7 @@ async function traceTurn(options) {
   let lastEndTime = turn.userTimestamp;
   for (const llmCall of turn.llmCalls) {
     const assistantContent = formatContent(llmCall.content);
-    const assistantRunId = uuid7();
+    const assistantRunId = llmCall.messageId ? deterministicUuid(`assistant:${llmCall.messageId}`) : uuid7();
     const assistantDottedOrderSegment = generateDottedOrderSegment(llmCall.startTime, assistantRunId);
     const assistantDottedOrder = `${parentDottedOrder}.${assistantDottedOrderSegment}`;
     const assistantRunTree = new RunTree({

--- a/bundle/stop-failure.js
+++ b/bundle/stop-failure.js
@@ -627,6 +627,9 @@ function debug(message) {
   }
 }
 
+// dist/langsmith.js
+import { createHash } from "node:crypto";
+
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/utils/uuid/src/regex.js
 var regex_default = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/i;
 

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -721,6 +721,7 @@ function mergeAssistantChunks(chunks) {
   const allBlocks = chunks.flatMap((c) => c.message.content);
   const merged = mergeAdjacentTextBlocks(allBlocks);
   return {
+    id: first.message.id,
     content: merged,
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage,
@@ -795,6 +796,7 @@ function groupIntoTurns(messages) {
         };
       });
       llmCalls.push({
+        messageId: merged.id,
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
@@ -975,6 +977,9 @@ function updateSessionState(state, sessionId, lastLine, turnCount, taskRunMap, c
     }
   };
 }
+
+// dist/langsmith.js
+import { createHash } from "node:crypto";
 
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/utils/uuid/src/regex.js
 var regex_default = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/i;
@@ -12589,6 +12594,13 @@ function generateDottedOrderSegment(time, runId) {
   const stripped = isoWithMicroseconds.replace(/[-:.]/g, "");
   return stripped + runId;
 }
+function deterministicUuid(key) {
+  const h = createHash("sha256").update(key).digest("hex").slice(0, 32).split("");
+  h[12] = "8";
+  h[16] = (parseInt(h[16], 16) & 3 | 8).toString(16);
+  const s = h.join("");
+  return `${s.slice(0, 8)}-${s.slice(8, 12)}-${s.slice(12, 16)}-${s.slice(16, 20)}-${s.slice(20, 32)}`;
+}
 function formatContent(blocks) {
   return blocks.map((block) => {
     switch (block.type) {
@@ -12678,7 +12690,7 @@ async function traceTurn(options) {
   let lastEndTime = turn.userTimestamp;
   for (const llmCall of turn.llmCalls) {
     const assistantContent = formatContent(llmCall.content);
-    const assistantRunId = uuid7();
+    const assistantRunId = llmCall.messageId ? deterministicUuid(`assistant:${llmCall.messageId}`) : uuid7();
     const assistantDottedOrderSegment = generateDottedOrderSegment(llmCall.startTime, assistantRunId);
     const assistantDottedOrder = `${parentDottedOrder}.${assistantDottedOrderSegment}`;
     const assistantRunTree = new RunTree({

--- a/bundle/subagent-stop.js
+++ b/bundle/subagent-stop.js
@@ -695,6 +695,9 @@ function getSessionState(state, sessionId) {
 }
 var SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 
+// dist/langsmith.js
+import { createHash } from "node:crypto";
+
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/utils/uuid/src/regex.js
 var regex_default = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/i;
 
@@ -12333,6 +12336,7 @@ function mergeAssistantChunks(chunks) {
   const allBlocks = chunks.flatMap((c) => c.message.content);
   const merged = mergeAdjacentTextBlocks(allBlocks);
   return {
+    id: first.message.id,
     content: merged,
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage,
@@ -12407,6 +12411,7 @@ function groupIntoTurns(messages) {
         };
       });
       llmCalls.push({
+        messageId: merged.id,
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
@@ -12529,6 +12534,13 @@ function generateDottedOrderSegment(time, runId) {
   const stripped = isoWithMicroseconds.replace(/[-:.]/g, "");
   return stripped + runId;
 }
+function deterministicUuid(key) {
+  const h = createHash("sha256").update(key).digest("hex").slice(0, 32).split("");
+  h[12] = "8";
+  h[16] = (parseInt(h[16], 16) & 3 | 8).toString(16);
+  const s = h.join("");
+  return `${s.slice(0, 8)}-${s.slice(8, 12)}-${s.slice(12, 16)}-${s.slice(16, 20)}-${s.slice(20, 32)}`;
+}
 function formatContent(blocks) {
   return blocks.map((block) => {
     switch (block.type) {
@@ -12618,7 +12630,7 @@ async function traceTurn(options) {
   let lastEndTime = turn.userTimestamp;
   for (const llmCall of turn.llmCalls) {
     const assistantContent = formatContent(llmCall.content);
-    const assistantRunId = uuid7();
+    const assistantRunId = llmCall.messageId ? deterministicUuid(`assistant:${llmCall.messageId}`) : uuid7();
     const assistantDottedOrderSegment = generateDottedOrderSegment(llmCall.startTime, assistantRunId);
     const assistantDottedOrder = `${parentDottedOrder}.${assistantDottedOrderSegment}`;
     const assistantRunTree = new RunTree({

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -11958,6 +11958,9 @@ function debug(message) {
   }
 }
 
+// dist/langsmith.js
+import { createHash } from "node:crypto";
+
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/anonymizer/index.js
 function extractStringNodes(data, options) {
   const parsedOptions = { ...options, maxDepth: options.maxDepth ?? 10 };
@@ -12340,6 +12343,7 @@ function mergeAssistantChunks(chunks) {
   const allBlocks = chunks.flatMap((c) => c.message.content);
   const merged = mergeAdjacentTextBlocks(allBlocks);
   return {
+    id: first.message.id,
     content: merged,
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage,
@@ -12414,6 +12418,7 @@ function groupIntoTurns(messages) {
         };
       });
       llmCalls.push({
+        messageId: merged.id,
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
@@ -12598,6 +12603,13 @@ function generateDottedOrderSegment(time, runId) {
   const stripped = isoWithMicroseconds.replace(/[-:.]/g, "");
   return stripped + runId;
 }
+function deterministicUuid(key) {
+  const h = createHash("sha256").update(key).digest("hex").slice(0, 32).split("");
+  h[12] = "8";
+  h[16] = (parseInt(h[16], 16) & 3 | 8).toString(16);
+  const s = h.join("");
+  return `${s.slice(0, 8)}-${s.slice(8, 12)}-${s.slice(12, 16)}-${s.slice(16, 20)}-${s.slice(20, 32)}`;
+}
 function runIdFromSegment(segment) {
   const zIdx = segment.indexOf("Z");
   return zIdx >= 0 ? segment.slice(zIdx + 1) : segment;
@@ -12697,7 +12709,7 @@ async function traceTurn(options) {
   let lastEndTime = turn.userTimestamp;
   for (const llmCall of turn.llmCalls) {
     const assistantContent = formatContent(llmCall.content);
-    const assistantRunId = uuid7();
+    const assistantRunId = llmCall.messageId ? deterministicUuid(`assistant:${llmCall.messageId}`) : uuid7();
     const assistantDottedOrderSegment = generateDottedOrderSegment(llmCall.startTime, assistantRunId);
     const assistantDottedOrder = `${parentDottedOrder}.${assistantDottedOrderSegment}`;
     const assistantRunTree = new RunTree({

--- a/src/langsmith.ts
+++ b/src/langsmith.ts
@@ -6,6 +6,7 @@
  * serialization, retries, and auth automatically.
  */
 
+import { createHash } from "node:crypto";
 import { Client, RunTree, RunTreeConfig, uuid7 } from "langsmith";
 import { createSecretAnonymizer } from "langsmith/anonymizer";
 import type { StringNodeRule } from "langsmith/anonymizer";
@@ -77,6 +78,18 @@ export function generateDottedOrderSegment(time: string | number, runId: string)
   // Strip non-alphanumeric characters
   const stripped = isoWithMicroseconds.replace(/[-:.]/g, "");
   return stripped + runId;
+}
+
+/**
+ * Derive a deterministic UUID from a stable key. Re-tracing the same key yields
+ * the same run ID, so LangSmith upserts instead of creating a duplicate run.
+ */
+export function deterministicUuid(key: string): string {
+  const h = createHash("sha256").update(key).digest("hex").slice(0, 32).split("");
+  h[12] = "8"; // version nibble
+  h[16] = ((parseInt(h[16], 16) & 0x3) | 0x8).toString(16); // variant nibble
+  const s = h.join("");
+  return `${s.slice(0, 8)}-${s.slice(8, 12)}-${s.slice(12, 16)}-${s.slice(16, 20)}-${s.slice(20, 32)}`;
 }
 
 /**
@@ -278,8 +291,10 @@ export async function traceTurn(
   for (const llmCall of turn.llmCalls) {
     const assistantContent = formatContent(llmCall.content);
 
-    // Generate run ID for this LLM call
-    const assistantRunId = uuid7();
+    // Deterministic ID (keyed on message.id) so a re-trace upserts, not duplicates.
+    const assistantRunId = llmCall.messageId
+      ? deterministicUuid(`assistant:${llmCall.messageId}`)
+      : uuid7();
     const assistantDottedOrderSegment = generateDottedOrderSegment(
       llmCall.startTime,
       assistantRunId,

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -236,6 +236,7 @@ export function stripModelDateSuffix(model: string): string {
  * into a single LLM call with concatenated text and final-chunk usage.
  */
 function mergeAssistantChunks(chunks: AssistantMessage[]): {
+  id: string | undefined;
   content: ContentBlock[];
   model: string;
   usage: Usage;
@@ -254,6 +255,7 @@ function mergeAssistantChunks(chunks: AssistantMessage[]): {
   const merged = mergeAdjacentTextBlocks(allBlocks);
 
   return {
+    id: first.message.id,
     content: merged,
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage, // SSE usage is cumulative; last chunk has final totals.
@@ -371,6 +373,7 @@ export function groupIntoTurns(messages: TranscriptMessage[]): Turn[] {
       });
 
       llmCalls.push({
+        messageId: merged.id,
         content: merged.content,
         model: merged.model,
         usage: merged.usage,

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,8 @@ export interface ToolCall {
 
 /** A single LLM response, possibly with tool calls. */
 export interface LLMCall {
+  /** Transcript assistant message.id — keys the run's deterministic ID. */
+  messageId?: string;
   /** Merged content from all streaming chunks. */
   content: ContentBlock[];
   /** Model name (date suffix stripped). */


### PR DESCRIPTION
## Summary
Duplicate LLM runs were showing up in traces under a single Turn (subagent and workflow subtrees were unaffected).
Assistant/LLM runs got a fresh random ID on every trace, so the only thing preventing a re-trace from creating a twin was the `last_line` cursor advancing - which is outside the state lock. So any path that traces the same turn twice against the same cursor produces duplicates (2 Stop hooks racing or a Stop that traces+dies and gets re-traced by a `closeInterruptedTurn`).

## Fix
Derive the assistant run ID deterministically from the transcript `message.id`. A re-trace now yields the same ID and LangSmith upserts instead of creating a duplicate. Synthetic final-message calls (no `message.id`) keep using `uuid7()`.

## Testing

- `pnpm test` - 258 passing
- `tsc --noEmit` - clean