### PR TITLE
fix: label Bedrock provider so CC-on-Bedrock traces get priced

### DIFF
--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -12293,7 +12293,12 @@ function stripModelDateSuffix(model) {
   return model.replace(/-\d{8}$/, "");
 }
 function resolveProvider(model) {
-  return /^([a-z-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
+  const flag = (name) => ["1", "true"].includes((process.env[name] ?? "").toLowerCase());
+  if (flag("CLAUDE_CODE_USE_BEDROCK"))
+    return "amazon_bedrock";
+  if (flag("CLAUDE_CODE_USE_VERTEX"))
+    return "google_vertex_ai";
+  return /^([a-z0-9-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
 }
 function mergeAssistantChunks(chunks) {
   if (chunks.length === 0) {

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -12292,6 +12292,9 @@ function isAssistantMessage(msg) {
 function stripModelDateSuffix(model) {
   return model.replace(/-\d{8}$/, "");
 }
+function resolveProvider(model) {
+  return /^([a-z-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
+}
 function mergeAssistantChunks(chunks) {
   if (chunks.length === 0) {
     throw new Error("Cannot merge zero chunks");
@@ -12740,7 +12743,7 @@ async function traceTurn(options) {
           turnNumber: turnNum,
           runtimeVersion,
           runSpecific: {
-            ls_provider: "anthropic",
+            ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
               model: llmCall.model

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -712,6 +712,9 @@ function isAssistantMessage(msg) {
 function stripModelDateSuffix(model) {
   return model.replace(/-\d{8}$/, "");
 }
+function resolveProvider(model) {
+  return /^([a-z-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
+}
 function mergeAssistantChunks(chunks) {
   if (chunks.length === 0) {
     throw new Error("Cannot merge zero chunks");
@@ -12770,7 +12773,7 @@ async function traceTurn(options) {
           turnNumber: turnNum,
           runtimeVersion,
           runSpecific: {
-            ls_provider: "anthropic",
+            ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
               model: llmCall.model

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -713,7 +713,12 @@ function stripModelDateSuffix(model) {
   return model.replace(/-\d{8}$/, "");
 }
 function resolveProvider(model) {
-  return /^([a-z-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
+  const flag = (name) => ["1", "true"].includes((process.env[name] ?? "").toLowerCase());
+  if (flag("CLAUDE_CODE_USE_BEDROCK"))
+    return "amazon_bedrock";
+  if (flag("CLAUDE_CODE_USE_VERTEX"))
+    return "google_vertex_ai";
+  return /^([a-z0-9-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
 }
 function mergeAssistantChunks(chunks) {
   if (chunks.length === 0) {

--- a/bundle/subagent-stop.js
+++ b/bundle/subagent-stop.js
@@ -12325,7 +12325,12 @@ function stripModelDateSuffix(model) {
   return model.replace(/-\d{8}$/, "");
 }
 function resolveProvider(model) {
-  return /^([a-z-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
+  const flag = (name) => ["1", "true"].includes((process.env[name] ?? "").toLowerCase());
+  if (flag("CLAUDE_CODE_USE_BEDROCK"))
+    return "amazon_bedrock";
+  if (flag("CLAUDE_CODE_USE_VERTEX"))
+    return "google_vertex_ai";
+  return /^([a-z0-9-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
 }
 function mergeAssistantChunks(chunks) {
   if (chunks.length === 0) {

--- a/bundle/subagent-stop.js
+++ b/bundle/subagent-stop.js
@@ -12324,6 +12324,9 @@ function isAssistantMessage(msg) {
 function stripModelDateSuffix(model) {
   return model.replace(/-\d{8}$/, "");
 }
+function resolveProvider(model) {
+  return /^([a-z-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
+}
 function mergeAssistantChunks(chunks) {
   if (chunks.length === 0) {
     throw new Error("Cannot merge zero chunks");
@@ -12710,7 +12713,7 @@ async function traceTurn(options) {
           turnNumber: turnNum,
           runtimeVersion,
           runSpecific: {
-            ls_provider: "anthropic",
+            ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
               model: llmCall.model

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -12332,7 +12332,12 @@ function stripModelDateSuffix(model) {
   return model.replace(/-\d{8}$/, "");
 }
 function resolveProvider(model) {
-  return /^([a-z-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
+  const flag = (name) => ["1", "true"].includes((process.env[name] ?? "").toLowerCase());
+  if (flag("CLAUDE_CODE_USE_BEDROCK"))
+    return "amazon_bedrock";
+  if (flag("CLAUDE_CODE_USE_VERTEX"))
+    return "google_vertex_ai";
+  return /^([a-z0-9-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
 }
 function mergeAssistantChunks(chunks) {
   if (chunks.length === 0) {

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -12331,6 +12331,9 @@ function isAssistantMessage(msg) {
 function stripModelDateSuffix(model) {
   return model.replace(/-\d{8}$/, "");
 }
+function resolveProvider(model) {
+  return /^([a-z-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
+}
 function mergeAssistantChunks(chunks) {
   if (chunks.length === 0) {
     throw new Error("Cannot merge zero chunks");
@@ -12789,7 +12792,7 @@ async function traceTurn(options) {
           turnNumber: turnNum,
           runtimeVersion,
           runSpecific: {
-            ls_provider: "anthropic",
+            ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
               model: llmCall.model

--- a/src/langsmith.ts
+++ b/src/langsmith.ts
@@ -10,7 +10,7 @@ import { Client, RunTree, RunTreeConfig, uuid7 } from "langsmith";
 import { createSecretAnonymizer } from "langsmith/anonymizer";
 import type { StringNodeRule } from "langsmith/anonymizer";
 import type { Turn, ContentBlock, Usage, OpenTurn, SessionState } from "./types.js";
-import { readTranscript, groupIntoTurns } from "./transcript.js";
+import { readTranscript, groupIntoTurns, resolveProvider } from "./transcript.js";
 import { loadState, getSessionState } from "./state.js";
 import * as logger from "./logger.js";
 import { ASSISTANT_RUN_NAME, USER_PROMPT_TURN_NAME } from "./constants.js";
@@ -396,7 +396,7 @@ export async function traceTurn(
           turnNumber: turnNum,
           runtimeVersion,
           runSpecific: {
-            ls_provider: "anthropic",
+            ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
               model: llmCall.model,

--- a/src/transcript.test.ts
+++ b/src/transcript.test.ts
@@ -302,6 +302,11 @@ describe("stripModelDateSuffix", () => {
 // ─── resolveProvider ────────────────────────────────────────────────────────
 
 describe("resolveProvider", () => {
+  afterEach(() => {
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+    delete process.env.CLAUDE_CODE_USE_VERTEX;
+  });
+
   it("labels first-party Anthropic ids as anthropic", () => {
     expect(resolveProvider("claude-sonnet-4-5")).toBe("anthropic");
   });
@@ -313,6 +318,17 @@ describe("resolveProvider", () => {
 
   it("labels bare Bedrock ids (no region prefix) as amazon_bedrock", () => {
     expect(resolveProvider("anthropic.claude-sonnet-5")).toBe("amazon_bedrock");
+  });
+
+  it("labels any model as amazon_bedrock when the Bedrock env flag is set", () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    expect(resolveProvider("openai.gpt-oss-120b")).toBe("amazon_bedrock");
+    expect(resolveProvider("amazon.nova-pro-v1:0")).toBe("amazon_bedrock");
+  });
+
+  it("labels any model as google_vertex_ai when the Vertex env flag is set", () => {
+    process.env.CLAUDE_CODE_USE_VERTEX = "true";
+    expect(resolveProvider("claude-sonnet-5")).toBe("google_vertex_ai");
   });
 });
 

--- a/src/transcript.test.ts
+++ b/src/transcript.test.ts
@@ -9,6 +9,7 @@ import {
   isToolResult,
   isAssistantMessage,
   stripModelDateSuffix,
+  resolveProvider,
   groupIntoTurns,
 } from "./transcript.js";
 import type {
@@ -295,6 +296,23 @@ describe("stripModelDateSuffix", () => {
 
   it("handles model with only numbers that are not a date suffix", () => {
     expect(stripModelDateSuffix("claude-3")).toBe("claude-3");
+  });
+});
+
+// ─── resolveProvider ────────────────────────────────────────────────────────
+
+describe("resolveProvider", () => {
+  it("labels first-party Anthropic ids as anthropic", () => {
+    expect(resolveProvider("claude-sonnet-4-5")).toBe("anthropic");
+  });
+
+  it("labels region-prefixed Bedrock ids as amazon_bedrock", () => {
+    expect(resolveProvider("us.anthropic.claude-sonnet-4-6")).toBe("amazon_bedrock");
+    expect(resolveProvider("us-gov.anthropic.claude-opus-4-8")).toBe("amazon_bedrock");
+  });
+
+  it("labels bare Bedrock ids (no region prefix) as amazon_bedrock", () => {
+    expect(resolveProvider("anthropic.claude-sonnet-5")).toBe("amazon_bedrock");
   });
 });
 

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -229,9 +229,12 @@ export function stripModelDateSuffix(model: string): string {
   return model.replace(/-\d{8}$/, "");
 }
 
-/** Bedrock Claude ids look like "us.anthropic.claude-..."; label them so pricing matches. */
+/** Resolve model provider from Claude Code's routing env, falling back to the model id. */
 export function resolveProvider(model: string): string {
-  return /^([a-z-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
+  const flag = (name: string) => ["1", "true"].includes((process.env[name] ?? "").toLowerCase());
+  if (flag("CLAUDE_CODE_USE_BEDROCK")) return "amazon_bedrock";
+  if (flag("CLAUDE_CODE_USE_VERTEX")) return "google_vertex_ai";
+  return /^([a-z0-9-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
 }
 
 // ─── Streaming merge ────────────────────────────────────────────────────────

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -229,6 +229,11 @@ export function stripModelDateSuffix(model: string): string {
   return model.replace(/-\d{8}$/, "");
 }
 
+/** Bedrock Claude ids look like "us.anthropic.claude-..."; label them so pricing matches. */
+export function resolveProvider(model: string): string {
+  return /^([a-z-]+\.)?anthropic\.claude/.test(model) ? "amazon_bedrock" : "anthropic";
+}
+
 // ─── Streaming merge ────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Description
When Claude Code runs against Amazon Bedrock (CLAUDE_CODE_USE_BEDROCK=1), we captured traces and token counts fine but hardcoded ls_provider: "anthropic" and passed the us.anthropic.claude-… model id straight through. In the model price map, the provider gate then skipped the Bedrock rows (provider='amazon_bedrock') and the dotted id didn't match the native ^claude-…$ regex either — so these runs stay unpriced.

## Changes
- Adds resolveProvider(model), which labels Bedrock-shaped ids ([region.]anthropic.claude-…, incl. us-gov. and bare anthropic.) as amazon_bedrock and everything else as anthropic. 
- Detection is by model-id shape rather than env flag so the emitted ls_provider always aligns with the price row whose regex matches the id (no model-name normalization needed - the dotted id already matches regex).

## Notes
Scoped to Bedrock for now; Vertex / third-party (OSS) providers can follow the same pattern later.

## Testing 
- 3 new cases for resolveProvider; full suite 261 passing.