### PR TITLE
fix: tag all subagent child runs with subagent identity

### DIFF
--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -12591,8 +12591,9 @@ function buildUsageMetadata(usage) {
   };
 }
 async function traceTurn(options) {
-  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata, runtimeVersion, approvalPolicy } = options;
+  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata, runtimeVersion, approvalPolicy, subagentId, subagentType } = options;
   const turnId = turn.promptId;
+  const subagentRole = subagentType ? "subagent" : void 0;
   let traceId = providedTraceId;
   let parentDottedOrder = providedParentDottedOrder;
   if (!client && !replicas) {
@@ -12701,6 +12702,9 @@ async function traceTurn(options) {
             turnId,
             turnNumber: turnNum,
             runtimeVersion,
+            legacyRole: subagentRole,
+            subagentId,
+            subagentType,
             toolName: toolCall.tool_use.name,
             runName: toolCall.tool_use.name
           })
@@ -12739,6 +12743,9 @@ async function traceTurn(options) {
           turnId,
           turnNumber: turnNum,
           runtimeVersion,
+          legacyRole: subagentRole,
+          subagentId,
+          subagentType,
           runSpecific: {
             ls_provider: "anthropic",
             ls_model_name: llmCall.model,
@@ -13076,7 +13083,9 @@ async function traceSubagentChain(opts) {
       traceId: opts.parentTraceId,
       parentDottedOrder: subagentChainDottedOrder,
       customMetadata: opts.customMetadata,
-      runtimeVersion: opts.runtimeVersion
+      runtimeVersion: opts.runtimeVersion,
+      subagentId: opts.subagentId,
+      subagentType: opts.subagentType
     });
   }
   log(`Traced subagent ${opts.subagentType} (${opts.subagentId}): ${opts.subagentTurns.length} turn(s)`);

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -12621,8 +12621,9 @@ function buildUsageMetadata(usage) {
   };
 }
 async function traceTurn(options) {
-  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata, runtimeVersion, approvalPolicy } = options;
+  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata, runtimeVersion, approvalPolicy, subagentId, subagentType } = options;
   const turnId = turn.promptId;
+  const subagentRole = subagentType ? "subagent" : void 0;
   let traceId = providedTraceId;
   let parentDottedOrder = providedParentDottedOrder;
   if (!client && !replicas) {
@@ -12731,6 +12732,9 @@ async function traceTurn(options) {
             turnId,
             turnNumber: turnNum,
             runtimeVersion,
+            legacyRole: subagentRole,
+            subagentId,
+            subagentType,
             toolName: toolCall.tool_use.name,
             runName: toolCall.tool_use.name
           })
@@ -12769,6 +12773,9 @@ async function traceTurn(options) {
           turnId,
           turnNumber: turnNum,
           runtimeVersion,
+          legacyRole: subagentRole,
+          subagentId,
+          subagentType,
           runSpecific: {
             ls_provider: "anthropic",
             ls_model_name: llmCall.model,
@@ -13020,7 +13027,9 @@ async function traceSubagentChain(opts) {
       traceId: opts.parentTraceId,
       parentDottedOrder: subagentChainDottedOrder,
       customMetadata: opts.customMetadata,
-      runtimeVersion: opts.runtimeVersion
+      runtimeVersion: opts.runtimeVersion,
+      subagentId: opts.subagentId,
+      subagentType: opts.subagentType
     });
   }
   log(`Traced subagent ${opts.subagentType} (${opts.subagentId}): ${opts.subagentTurns.length} turn(s)`);

--- a/bundle/subagent-stop.js
+++ b/bundle/subagent-stop.js
@@ -12561,8 +12561,9 @@ function buildUsageMetadata(usage) {
   };
 }
 async function traceTurn(options) {
-  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata, runtimeVersion, approvalPolicy } = options;
+  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata, runtimeVersion, approvalPolicy, subagentId, subagentType } = options;
   const turnId = turn.promptId;
+  const subagentRole = subagentType ? "subagent" : void 0;
   let traceId = providedTraceId;
   let parentDottedOrder = providedParentDottedOrder;
   if (!client && !replicas) {
@@ -12671,6 +12672,9 @@ async function traceTurn(options) {
             turnId,
             turnNumber: turnNum,
             runtimeVersion,
+            legacyRole: subagentRole,
+            subagentId,
+            subagentType,
             toolName: toolCall.tool_use.name,
             runName: toolCall.tool_use.name
           })
@@ -12709,6 +12713,9 @@ async function traceTurn(options) {
           turnId,
           turnNumber: turnNum,
           runtimeVersion,
+          legacyRole: subagentRole,
+          subagentId,
+          subagentType,
           runSpecific: {
             ls_provider: "anthropic",
             ls_model_name: llmCall.model,
@@ -12960,7 +12967,9 @@ async function traceSubagentChain(opts) {
       traceId: opts.parentTraceId,
       parentDottedOrder: subagentChainDottedOrder,
       customMetadata: opts.customMetadata,
-      runtimeVersion: opts.runtimeVersion
+      runtimeVersion: opts.runtimeVersion,
+      subagentId: opts.subagentId,
+      subagentType: opts.subagentType
     });
   }
   log(`Traced subagent ${opts.subagentType} (${opts.subagentId}): ${opts.subagentTurns.length} turn(s)`);

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -12640,8 +12640,9 @@ function buildUsageMetadata(usage) {
   };
 }
 async function traceTurn(options) {
-  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata, runtimeVersion, approvalPolicy } = options;
+  const { turn, sessionId, turnNum, project, parentRunId, existingTaskRunMap, tracedToolUseIds, traceId: providedTraceId, parentDottedOrder: providedParentDottedOrder, customMetadata, runtimeVersion, approvalPolicy, subagentId, subagentType } = options;
   const turnId = turn.promptId;
+  const subagentRole = subagentType ? "subagent" : void 0;
   let traceId = providedTraceId;
   let parentDottedOrder = providedParentDottedOrder;
   if (!client && !replicas) {
@@ -12750,6 +12751,9 @@ async function traceTurn(options) {
             turnId,
             turnNumber: turnNum,
             runtimeVersion,
+            legacyRole: subagentRole,
+            subagentId,
+            subagentType,
             toolName: toolCall.tool_use.name,
             runName: toolCall.tool_use.name
           })
@@ -12788,6 +12792,9 @@ async function traceTurn(options) {
           turnId,
           turnNumber: turnNum,
           runtimeVersion,
+          legacyRole: subagentRole,
+          subagentId,
+          subagentType,
           runSpecific: {
             ls_provider: "anthropic",
             ls_model_name: llmCall.model,
@@ -13125,7 +13132,9 @@ async function traceSubagentChain(opts) {
       traceId: opts.parentTraceId,
       parentDottedOrder: subagentChainDottedOrder,
       customMetadata: opts.customMetadata,
-      runtimeVersion: opts.runtimeVersion
+      runtimeVersion: opts.runtimeVersion,
+      subagentId: opts.subagentId,
+      subagentType: opts.subagentType
     });
   }
   log(`Traced subagent ${opts.subagentType} (${opts.subagentId}): ${opts.subagentTurns.length} turn(s)`);

--- a/src/langsmith.test.ts
+++ b/src/langsmith.test.ts
@@ -1409,4 +1409,55 @@ describe("traceTurn", () => {
     });
     expect(turnMeta.ls_subagent_type).toBeUndefined(); // never on root
   });
+
+  it("stamps subagent identity on every child run (LLM + tool) of a subagent", async () => {
+    const turn: Turn = {
+      userContent: "do stuff",
+      userTimestamp: "2025-01-01T00:00:00Z",
+      promptId: "prompt_sub",
+      llmCalls: [
+        {
+          content: [{ type: "text", text: "working" }],
+          model: "claude-sonnet-4-5",
+          usage: { input_tokens: 10, output_tokens: 5 },
+          startTime: "2025-01-01T00:00:01Z",
+          endTime: "2025-01-01T00:00:02Z",
+          toolCalls: [
+            {
+              tool_use: { type: "tool_use", id: "tu_1", name: "Bash", input: { command: "ls" } },
+              result: { content: "ok", timestamp: "2025-01-01T00:00:03Z" },
+            },
+          ],
+        },
+      ],
+      isComplete: true,
+    };
+
+    await traceTurn({
+      turn,
+      sessionId: "session-123",
+      turnNum: 1,
+      project: "test-project",
+      parentRunId: "chain-run-id",
+      traceId: "trace-id",
+      parentDottedOrder: "20250101T000000000Z001chain-run-id",
+      subagentId: "sub_4d8e1f",
+      subagentType: "Explore",
+    });
+
+    for (const runType of ["llm", "tool"]) {
+      const inst = allRunTreeInstances.find(
+        (i) => i.params.run_type === runType && i.params.extra,
+      )!;
+      const meta = (inst.params.extra as Record<string, unknown>).metadata as Record<
+        string,
+        unknown
+      >;
+      expect(meta.ls_agent_type).toBe("subagent"); // DEPRECATED compat alias
+      expect(meta.ls_subagent_type).toBe("Explore");
+      expect(meta.ls_subagent_id).toBe("sub_4d8e1f");
+      expect(meta.agent_type).toBe("Explore"); // DEPRECATED compat alias
+      expect(meta.agent_id).toBe("sub_4d8e1f"); // DEPRECATED compat alias
+    }
+  });
 });

--- a/src/langsmith.ts
+++ b/src/langsmith.ts
@@ -172,6 +172,9 @@ export interface TraceTurnOptions {
   runtimeVersion?: string;
   /** Permission mode → `approval_policy` (stamped on root/standalone turn runs only). */
   approvalPolicy?: string;
+  /** Subagent identity — when set, this turn's runs belong to a subagent. */
+  subagentId?: string;
+  subagentType?: string;
 }
 
 /**
@@ -194,10 +197,15 @@ export async function traceTurn(
     customMetadata,
     runtimeVersion,
     approvalPolicy,
+    subagentId,
+    subagentType,
   } = options;
 
   // turn_id for every run created for this turn (transcript promptId).
   const turnId = turn.promptId;
+
+  // Subagent turns stamp their identity on every child run (parity with the chain).
+  const subagentRole = subagentType ? "subagent" : undefined;
 
   let traceId = providedTraceId;
   let parentDottedOrder = providedParentDottedOrder;
@@ -350,6 +358,9 @@ export async function traceTurn(
             turnId,
             turnNumber: turnNum,
             runtimeVersion,
+            legacyRole: subagentRole,
+            subagentId,
+            subagentType,
             toolName: toolCall.tool_use.name,
             runName: toolCall.tool_use.name,
           }),
@@ -395,6 +406,9 @@ export async function traceTurn(
           turnId,
           turnNumber: turnNum,
           runtimeVersion,
+          legacyRole: subagentRole,
+          subagentId,
+          subagentType,
           runSpecific: {
             ls_provider: "anthropic",
             ls_model_name: llmCall.model,
@@ -992,6 +1006,8 @@ async function traceSubagentChain(opts: {
       parentDottedOrder: subagentChainDottedOrder,
       customMetadata: opts.customMetadata,
       runtimeVersion: opts.runtimeVersion,
+      subagentId: opts.subagentId,
+      subagentType: opts.subagentType,
     });
   }
 


### PR DESCRIPTION
## Description
The subagent-tracing refactor routed subagent turns through the shared traceTurn, which carried no subagent context. As a result only the subagent chain run kept ls_agent_type: "subagent" / ls_subagent_type (nested LLM/tool runs stopped being tagged, so deep subagent runs were no longer attributable in LangSmith).

## Changes
- Adds optional subagentId/subagentType to TraceTurnOptions; when set, traceTurn stamps ls_agent_type: "subagent" + ls_subagent_type/ls_subagent_id (and the agent_type/agent_id compat aliases) on every child LLM and tool run (parity with the chain run).
- traceSubagentChain now forwards the subagent identity into its traceTurn calls. Since workflow stages share traceSubagentChain, workflow-stage child runs get the same tagging automatically.
- Root/standalone turns pass no subagent identity, so their leaf runs stay untagged (unchanged behavior).

## Testing
- [x] New test: subagent LLM + tool child runs carry ls_agent_type/ls_subagent_type/ls_subagent_id + aliases, existing test still asserts root leaf runs stay untagged.
- [x] Full suite 259 passing.
- [x] View manual trace: [here](https://smith.langchain.com/o/ebbaf2eb-769b-4505-aca2-d11de10372a4/projects/p/fb2d5cad-6d02-42d1-9656-47db0bd2c914?timeModel=%7B%22duration%22%3A%2230d%22%7D&peek=20260709T234716Z019f4947-4a77-7581-a620-4e0da8bda1a9&peekedConversationId=825a4ca4-17cf-4949-aed0-aa8552d2c251&trace_id=019f4947-4a77-7581-a620-4e0da8bda1a9&run_id=20260709T234724Z019f4947-7e6c-750a-a9be-b5d1778db111&peeked_trace=20260709T234716728000Z019f4947-4a77-7581-a620-4e0da8bda1a9&conversationTab=trace&scroll_to=metadata)