### PR TITLE
feat: trace skill usage via ls_skill_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ All runs (LLM, tool, turn, subagent) automatically include identity metadata so 
 
 To override either field, supply your own value via `CC_LANGSMITH_METADATA` — user-supplied keys always win.
 
-Tool runs include the tool name, inputs, and output content.
+Tool runs include the tool name, inputs, and output content. Skill tool runs additionally set `ls_skill_name` — the invoked skill's name, read from the tool's `skill` input — so per-skill usage is queryable in run stats.
 
 Interrupted turns (where the user cancels mid-response) are marked with status `"interrupted"` in LangSmith.
 

--- a/bundle/post-compact.js
+++ b/bundle/post-compact.js
@@ -12240,7 +12240,7 @@ var LS_INTEGRATION = "claude-code";
 var LS_AGENT_RUNTIME = "Claude Code";
 var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
 function codingAgentMetadata(opts) {
-  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, skillName, runSpecific } = opts;
   const meta = {
     // Identity & grouping — always present.
     ls_agent_purpose: LS_AGENT_PURPOSE,
@@ -12271,6 +12271,8 @@ function codingAgentMetadata(opts) {
     if (runName && toolName !== runName)
       meta.ls_tool_name = toolName;
   }
+  if (skillName)
+    meta.ls_skill_name = skillName;
   return {
     ...meta,
     ...runSpecific,

--- a/bundle/post-tool-use.js
+++ b/bundle/post-tool-use.js
@@ -12240,7 +12240,7 @@ var LS_INTEGRATION = "claude-code";
 var LS_AGENT_RUNTIME = "Claude Code";
 var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
 function codingAgentMetadata(opts) {
-  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, skillName, runSpecific } = opts;
   const meta = {
     // Identity & grouping — always present.
     ls_agent_purpose: LS_AGENT_PURPOSE,
@@ -12271,11 +12271,19 @@ function codingAgentMetadata(opts) {
     if (runName && toolName !== runName)
       meta.ls_tool_name = toolName;
   }
+  if (skillName)
+    meta.ls_skill_name = skillName;
   return {
     ...meta,
     ...runSpecific,
     ...base
   };
+}
+function skillNameFromTool(toolName, toolInput) {
+  if (toolName !== "Skill")
+    return void 0;
+  const skill = toolInput?.skill;
+  return typeof skill === "string" ? skill : void 0;
 }
 
 // dist/langsmith.js
@@ -12663,7 +12671,8 @@ async function main() {
           runtimeVersion: sessionState.runtime_version,
           agentType: "root",
           toolName: input.tool_name,
-          runName: input.tool_name
+          runName: input.tool_name,
+          skillName: skillNameFromTool(input.tool_name, input.tool_input)
         })
       }
     });

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -12505,7 +12505,7 @@ var LS_INTEGRATION = "claude-code";
 var LS_AGENT_RUNTIME = "Claude Code";
 var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
 function codingAgentMetadata(opts) {
-  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, skillName, runSpecific } = opts;
   const meta = {
     // Identity & grouping — always present.
     ls_agent_purpose: LS_AGENT_PURPOSE,
@@ -12536,11 +12536,19 @@ function codingAgentMetadata(opts) {
     if (runName && toolName !== runName)
       meta.ls_tool_name = toolName;
   }
+  if (skillName)
+    meta.ls_skill_name = skillName;
   return {
     ...meta,
     ...runSpecific,
     ...base
   };
+}
+function skillNameFromTool(toolName, toolInput) {
+  if (toolName !== "Skill")
+    return void 0;
+  const skill = toolInput?.skill;
+  return typeof skill === "string" ? skill : void 0;
 }
 
 // dist/langsmith.js
@@ -12713,7 +12721,8 @@ async function traceTurn(options) {
             runtimeVersion,
             agentType,
             toolName: toolCall.tool_use.name,
-            runName: toolCall.tool_use.name
+            runName: toolCall.tool_use.name,
+            skillName: skillNameFromTool(toolCall.tool_use.name, toolCall.tool_use.input)
           })
         }
       });

--- a/bundle/stop-failure.js
+++ b/bundle/stop-failure.js
@@ -12238,7 +12238,7 @@ var LS_INTEGRATION = "claude-code";
 var LS_AGENT_RUNTIME = "Claude Code";
 var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
 function codingAgentMetadata(opts) {
-  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, skillName, runSpecific } = opts;
   const meta = {
     // Identity & grouping — always present.
     ls_agent_purpose: LS_AGENT_PURPOSE,
@@ -12269,6 +12269,8 @@ function codingAgentMetadata(opts) {
     if (runName && toolName !== runName)
       meta.ls_tool_name = toolName;
   }
+  if (skillName)
+    meta.ls_skill_name = skillName;
   return {
     ...meta,
     ...runSpecific,

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -12535,7 +12535,7 @@ var LS_INTEGRATION = "claude-code";
 var LS_AGENT_RUNTIME = "Claude Code";
 var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
 function codingAgentMetadata(opts) {
-  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, skillName, runSpecific } = opts;
   const meta = {
     // Identity & grouping — always present.
     ls_agent_purpose: LS_AGENT_PURPOSE,
@@ -12566,11 +12566,19 @@ function codingAgentMetadata(opts) {
     if (runName && toolName !== runName)
       meta.ls_tool_name = toolName;
   }
+  if (skillName)
+    meta.ls_skill_name = skillName;
   return {
     ...meta,
     ...runSpecific,
     ...base
   };
+}
+function skillNameFromTool(toolName, toolInput) {
+  if (toolName !== "Skill")
+    return void 0;
+  const skill = toolInput?.skill;
+  return typeof skill === "string" ? skill : void 0;
 }
 
 // dist/langsmith.js
@@ -12743,7 +12751,8 @@ async function traceTurn(options) {
             runtimeVersion,
             agentType,
             toolName: toolCall.tool_use.name,
-            runName: toolCall.tool_use.name
+            runName: toolCall.tool_use.name,
+            skillName: skillNameFromTool(toolCall.tool_use.name, toolCall.tool_use.input)
           })
         }
       });

--- a/bundle/subagent-stop.js
+++ b/bundle/subagent-stop.js
@@ -12475,7 +12475,7 @@ var LS_INTEGRATION = "claude-code";
 var LS_AGENT_RUNTIME = "Claude Code";
 var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
 function codingAgentMetadata(opts) {
-  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, skillName, runSpecific } = opts;
   const meta = {
     // Identity & grouping — always present.
     ls_agent_purpose: LS_AGENT_PURPOSE,
@@ -12506,11 +12506,19 @@ function codingAgentMetadata(opts) {
     if (runName && toolName !== runName)
       meta.ls_tool_name = toolName;
   }
+  if (skillName)
+    meta.ls_skill_name = skillName;
   return {
     ...meta,
     ...runSpecific,
     ...base
   };
+}
+function skillNameFromTool(toolName, toolInput) {
+  if (toolName !== "Skill")
+    return void 0;
+  const skill = toolInput?.skill;
+  return typeof skill === "string" ? skill : void 0;
 }
 
 // dist/langsmith.js
@@ -12683,7 +12691,8 @@ async function traceTurn(options) {
             runtimeVersion,
             agentType,
             toolName: toolCall.tool_use.name,
-            runName: toolCall.tool_use.name
+            runName: toolCall.tool_use.name,
+            skillName: skillNameFromTool(toolCall.tool_use.name, toolCall.tool_use.input)
           })
         }
       });

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -12544,7 +12544,7 @@ var LS_INTEGRATION = "claude-code";
 var LS_AGENT_RUNTIME = "Claude Code";
 var LS_TRACE_SCHEMA_VERSION = "coding-agent-v1";
 function codingAgentMetadata(opts) {
-  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, runSpecific } = opts;
+  const { sessionId, base, turnId, turnNumber, runtimeVersion, approvalPolicy, agentType, subagentId, subagentType, toolName, runName, skillName, runSpecific } = opts;
   const meta = {
     // Identity & grouping — always present.
     ls_agent_purpose: LS_AGENT_PURPOSE,
@@ -12575,11 +12575,19 @@ function codingAgentMetadata(opts) {
     if (runName && toolName !== runName)
       meta.ls_tool_name = toolName;
   }
+  if (skillName)
+    meta.ls_skill_name = skillName;
   return {
     ...meta,
     ...runSpecific,
     ...base
   };
+}
+function skillNameFromTool(toolName, toolInput) {
+  if (toolName !== "Skill")
+    return void 0;
+  const skill = toolInput?.skill;
+  return typeof skill === "string" ? skill : void 0;
 }
 
 // dist/langsmith.js
@@ -12762,7 +12770,8 @@ async function traceTurn(options) {
             runtimeVersion,
             agentType,
             toolName: toolCall.tool_use.name,
-            runName: toolCall.tool_use.name
+            runName: toolCall.tool_use.name,
+            skillName: skillNameFromTool(toolCall.tool_use.name, toolCall.tool_use.input)
           })
         }
       });

--- a/src/fixtures/coding-agent-v1/validator.json
+++ b/src/fixtures/coding-agent-v1/validator.json
@@ -144,6 +144,15 @@
       "requiredWhereKnown": true
     },
     {
+      "key": "ls_skill_name",
+      "appliesTo": ["tool"],
+      "type": "string",
+      "allowedValues": null,
+      "requirement": "contextual",
+      "requiredWhereKnown": false,
+      "note": "Invoked skill name; present only on Skill tool runs (from the Skill tool's `skill` input arg). Queryable via RunQueryStats group_by metadata path=ls_skill_name."
+    },
+    {
       "key": "user_id",
       "appliesTo": ["root", "llm", "tool", "subagent", "interrupted"],
       "type": "string",

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -13,7 +13,7 @@ import { initTracing, generateDottedOrderSegment, flushPendingTraces } from "../
 import { loadState, atomicUpdateState, getSessionState } from "../state.js";
 import { initHook } from "../utils/hook-init.js";
 import { readStdin } from "../utils/stdin.js";
-import { codingAgentMetadata } from "../metadata.js";
+import { codingAgentMetadata, skillNameFromTool } from "../metadata.js";
 import { recordBackgroundRun } from "../background-runs.js";
 import { detectWorkflowLaunch } from "../workflows.js";
 
@@ -150,6 +150,7 @@ async function main(): Promise<void> {
           agentType: "root",
           toolName: input.tool_name,
           runName: input.tool_name,
+          skillName: skillNameFromTool(input.tool_name, input.tool_input),
         }),
       },
     });

--- a/src/langsmith.ts
+++ b/src/langsmith.ts
@@ -14,7 +14,7 @@ import { readTranscript, groupIntoTurns, resolveProvider } from "./transcript.js
 import { loadState, getSessionState } from "./state.js";
 import * as logger from "./logger.js";
 import { ASSISTANT_RUN_NAME, USER_PROMPT_TURN_NAME } from "./constants.js";
-import { codingAgentMetadata } from "./metadata.js";
+import { codingAgentMetadata, skillNameFromTool } from "./metadata.js";
 import type { LSAgentType } from "./metadata.js";
 
 // ─── Client setup ───────────────────────────────────────────────────────────
@@ -357,6 +357,7 @@ export async function traceTurn(
             agentType,
             toolName: toolCall.tool_use.name,
             runName: toolCall.tool_use.name,
+            skillName: skillNameFromTool(toolCall.tool_use.name, toolCall.tool_use.input),
           }),
         },
       });

--- a/src/metadata.test.ts
+++ b/src/metadata.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { codingAgentMetadata } from "./metadata.js";
+import { codingAgentMetadata, skillNameFromTool } from "./metadata.js";
 import validator from "./fixtures/coding-agent-v1/validator.json" with { type: "json" };
 
 type RunType = "root" | "llm" | "tool" | "subagent" | "interrupted";
@@ -204,6 +204,34 @@ describe("coding-agent-v1 contract", () => {
     const meta = codingAgentMetadata({ ...COMMON, toolName: "Bash", runName: "Agent" });
     expect(meta.ls_tool_name).toBe("Bash");
     expect(meta.tool_name).toBe("Bash");
+  });
+
+  // ─── ls_skill_name: the invoked skill on Skill tool runs ─────────────────────
+
+  it("extracts the invoked skill name only from Skill tool calls", () => {
+    expect(skillNameFromTool("Skill", { skill: "deep-research", args: "x" })).toBe("deep-research");
+    expect(skillNameFromTool("Bash", { skill: "deep-research" })).toBeUndefined();
+    expect(skillNameFromTool("Skill", {})).toBeUndefined();
+    expect(skillNameFromTool("Skill", undefined)).toBeUndefined();
+    expect(skillNameFromTool("Skill", { skill: 42 })).toBeUndefined();
+  });
+
+  it("emits ls_skill_name on a Skill tool run, and nowhere else", () => {
+    const skillRun = codingAgentMetadata({
+      ...COMMON,
+      toolName: "Skill",
+      runName: "Skill",
+      skillName: skillNameFromTool("Skill", { skill: "deep-research", args: "compare" }),
+    });
+    expect(skillRun.ls_skill_name).toBe("deep-research");
+    expect(skillRun.tool_name).toBe("Skill");
+    expect(skillRun.ls_tool_name).toBeUndefined(); // run name == tool name
+
+    // Absent on non-skill tool runs and on every other run type.
+    expect(RUNS.tool.ls_skill_name).toBeUndefined();
+    for (const rt of ["root", "llm", "subagent", "interrupted"] as RunType[]) {
+      expect(RUNS[rt].ls_skill_name, `ls_skill_name leaked onto ${rt}`).toBeUndefined();
+    }
   });
 
   // ─── Model run keeps existing conventions unchanged ──────────────────────────

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -44,6 +44,10 @@ export interface CodingAgentMetadataOptions {
   /** Run `name` used to decide whether `ls_tool_name` is needed. */
   runName?: string;
 
+  /** Invoked skill name (Skill tool runs) → `ls_skill_name`, read from the
+   * Skill tool's `skill` input arg. */
+  skillName?: string;
+
   /** Preserved run-type keys (ls_provider, usage_metadata, …) and compat aliases. */
   runSpecific?: Record<string, unknown>;
 }
@@ -67,6 +71,7 @@ export function codingAgentMetadata(opts: CodingAgentMetadataOptions): Record<st
     subagentType,
     toolName,
     runName,
+    skillName,
     runSpecific,
   } = opts;
 
@@ -108,9 +113,28 @@ export function codingAgentMetadata(opts: CodingAgentMetadataOptions): Record<st
     if (runName && toolName !== runName) meta.ls_tool_name = toolName;
   }
 
+  // Skill tool runs: surface the invoked skill so usage is queryable via
+  // RunQueryStats (group_by metadata path=ls_skill_name).
+  if (skillName) meta.ls_skill_name = skillName;
+
   return {
     ...meta,
     ...runSpecific,
     ...base,
   };
+}
+
+/**
+ * Extract the invoked skill name from a tool call, for `ls_skill_name`.
+ * Centralizes the one "Skill" special-case so both trace paths stay one-liners.
+ * Returns undefined for non-Skill tools; the name lives in the Skill tool's
+ * `skill` input arg (`{ skill, args }`).
+ */
+export function skillNameFromTool(
+  toolName: string | undefined,
+  toolInput: unknown,
+): string | undefined {
+  if (toolName !== "Skill") return undefined;
+  const skill = (toolInput as { skill?: unknown } | null | undefined)?.skill;
+  return typeof skill === "string" ? skill : undefined;
 }


### PR DESCRIPTION
Emit **`ls_skill_name`** on every `Skill` tool run — read from the tool's `skill` input arg — wired through both trace paths (`langsmith.ts` + `hooks/post-tool-use.ts`).

## Why

This makes per-skill usage countable via `POST /v2/runs/stats` (`group_by` metadata `path=ls_skill_name`, select `group_count` for distinct sessions) over a 30-day horizon — far wider than a single Engine scan (a few thousand traces is only a day or two at our scale, so a skill unused within one scan is not evidence of an unused skill). LangSmith Engine's instruction auditor pulls this in to reason about skill activation.

No backend change is needed — `/v2/runs/stats` already supports metadata `group_by` end-to-end (`runsanalytics/run_stats_rpc.go` + a passing handler test).

## Privacy

Just the invoked skill name — no skill contents, no filesystem paths.

## Test plan

- `vitest run` — 274 passing, incl. the `coding-agent-v1` contract fixture (asserts no key emits outside its `appliesTo`).
- `tsc` + bundle + `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
