### PR TITLE
fix: ensure that UUID7's are generated with start_time in mind

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langsmith-tracing",
   "description": "Traces Claude Code conversations to LangSmith, including subagent and tool executions",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "LangChain"
   },

--- a/bundle/post-compact.js
+++ b/bundle/post-compact.js
@@ -11888,11 +11888,6 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/uuid.js
-function uuid7() {
-  return v7_default();
-}
-
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/singletons/traceable.js
 var MockAsyncLocalStorage = class {
   getStore() {
@@ -12552,7 +12547,7 @@ async function main() {
   const sessionState = getSessionState(state, input.session_id);
   const endTime = (/* @__PURE__ */ new Date()).toISOString();
   const startTime = sessionState.compaction_start_time ? new Date(sessionState.compaction_start_time).toISOString() : endTime;
-  const runId = uuid7();
+  const runId = uuid7FromTime(startTime);
   const segment = generateDottedOrderSegment(startTime, runId);
   const parentRunId = sessionState.current_turn_run_id;
   const traceId = sessionState.current_trace_id ?? runId;

--- a/bundle/post-compact.js
+++ b/bundle/post-compact.js
@@ -12308,7 +12308,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.2" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/post-tool-use.js
+++ b/bundle/post-tool-use.js
@@ -11888,11 +11888,6 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/uuid.js
-function uuid7() {
-  return v7_default();
-}
-
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/singletons/traceable.js
 var MockAsyncLocalStorage = class {
   getStore() {
@@ -12607,8 +12602,8 @@ async function main() {
     error("No current_turn_run_id or trace_id in state - UserPromptSubmit hook may not have run");
     return;
   }
-  const toolRunId = uuid7();
   const startTime = sessionState.tool_start_times?.[input.tool_use_id] ?? Date.now();
+  const toolRunId = uuid7FromTime(startTime);
   const toolEndTime = Date.now();
   const startTimeIso = new Date(startTime).toISOString();
   const toolEndTimeIso = new Date(toolEndTime).toISOString();

--- a/bundle/post-tool-use.js
+++ b/bundle/post-tool-use.js
@@ -12314,7 +12314,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.2" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/pre-compact.js
+++ b/bundle/pre-compact.js
@@ -104,7 +104,7 @@ import { readFileSync as readFileSync2 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.2" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/pre-tool-use.js
+++ b/bundle/pre-tool-use.js
@@ -104,7 +104,7 @@ import { readFileSync as readFileSync2 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.2" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -11931,11 +11931,6 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/uuid.js
-function uuid7() {
-  return v7_default();
-}
-
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/singletons/traceable.js
 var MockAsyncLocalStorage = class {
   getStore() {
@@ -12628,7 +12623,7 @@ async function traceTurn(options) {
     }
   } else {
     shouldCreateTurn = true;
-    turnRunId = uuid7();
+    turnRunId = uuid7FromTime(turn.userTimestamp);
     traceId = turnRunId;
     parentDottedOrder = generateDottedOrderSegment(turn.userTimestamp, turnRunId);
     debug(`Creating new standalone turn run ${turnRunId}`);
@@ -12666,7 +12661,7 @@ async function traceTurn(options) {
   let lastEndTime = turn.userTimestamp;
   for (const llmCall of turn.llmCalls) {
     const assistantContent = formatContent(llmCall.content);
-    const assistantRunId = uuid7();
+    const assistantRunId = uuid7FromTime(llmCall.startTime);
     const assistantDottedOrderSegment = generateDottedOrderSegment(llmCall.startTime, assistantRunId);
     const assistantDottedOrder = `${parentDottedOrder}.${assistantDottedOrderSegment}`;
     const assistantRunTree = new RunTree({
@@ -12695,7 +12690,7 @@ async function traceTurn(options) {
       }
       const toolEndTime = toolCall.result?.timestamp ?? llmCall.endTime;
       const toolStartTime = llmCall.endTime <= toolEndTime ? llmCall.endTime : toolEndTime;
-      const toolRunId = uuid7();
+      const toolRunId = uuid7FromTime(toolStartTime);
       const toolDottedOrderSegment = generateDottedOrderSegment(toolStartTime, toolRunId);
       const toolDottedOrder = `${parentDottedOrder}.${toolDottedOrderSegment}`;
       const runTree2 = new RunTree({
@@ -13052,7 +13047,7 @@ async function tracePendingSubagents(options) {
   return openedAgentRunIds;
 }
 async function traceSubagentChain(opts) {
-  const subagentChainId = uuid7();
+  const subagentChainId = uuid7FromTime(opts.startTime);
   const subagentChainDottedOrder = `${opts.parentDottedOrder}.${generateDottedOrderSegment(opts.startTime, subagentChainId)}`;
   const runTree = new RunTree({
     client,

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -13150,7 +13150,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.2" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/stop-failure.js
+++ b/bundle/stop-failure.js
@@ -12305,7 +12305,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.2" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -12282,11 +12282,6 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/uuid.js
-function uuid7() {
-  return v7_default();
-}
-
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/singletons/traceable.js
 var MockAsyncLocalStorage = class {
   getStore() {
@@ -12658,7 +12653,7 @@ async function traceTurn(options) {
     }
   } else {
     shouldCreateTurn = true;
-    turnRunId = uuid7();
+    turnRunId = uuid7FromTime(turn.userTimestamp);
     traceId = turnRunId;
     parentDottedOrder = generateDottedOrderSegment(turn.userTimestamp, turnRunId);
     debug(`Creating new standalone turn run ${turnRunId}`);
@@ -12696,7 +12691,7 @@ async function traceTurn(options) {
   let lastEndTime = turn.userTimestamp;
   for (const llmCall of turn.llmCalls) {
     const assistantContent = formatContent(llmCall.content);
-    const assistantRunId = uuid7();
+    const assistantRunId = uuid7FromTime(llmCall.startTime);
     const assistantDottedOrderSegment = generateDottedOrderSegment(llmCall.startTime, assistantRunId);
     const assistantDottedOrder = `${parentDottedOrder}.${assistantDottedOrderSegment}`;
     const assistantRunTree = new RunTree({
@@ -12725,7 +12720,7 @@ async function traceTurn(options) {
       }
       const toolEndTime = toolCall.result?.timestamp ?? llmCall.endTime;
       const toolStartTime = llmCall.endTime <= toolEndTime ? llmCall.endTime : toolEndTime;
-      const toolRunId = uuid7();
+      const toolRunId = uuid7FromTime(toolStartTime);
       const toolDottedOrderSegment = generateDottedOrderSegment(toolStartTime, toolRunId);
       const toolDottedOrder = `${parentDottedOrder}.${toolDottedOrderSegment}`;
       const runTree2 = new RunTree({
@@ -12996,7 +12991,7 @@ async function tracePendingSubagents(options) {
   return openedAgentRunIds;
 }
 async function traceSubagentChain(opts) {
-  const subagentChainId = uuid7();
+  const subagentChainId = uuid7FromTime(opts.startTime);
   const subagentChainDottedOrder = `${opts.parentDottedOrder}.${generateDottedOrderSegment(opts.startTime, subagentChainId)}`;
   const runTree = new RunTree({
     client,

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -13094,7 +13094,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.2" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/subagent-stop.js
+++ b/bundle/subagent-stop.js
@@ -13194,7 +13194,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.2" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/subagent-stop.js
+++ b/bundle/subagent-stop.js
@@ -11993,11 +11993,6 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/uuid.js
-function uuid7() {
-  return v7_default();
-}
-
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/singletons/traceable.js
 var MockAsyncLocalStorage = class {
   getStore() {
@@ -12598,7 +12593,7 @@ async function traceTurn(options) {
     }
   } else {
     shouldCreateTurn = true;
-    turnRunId = uuid7();
+    turnRunId = uuid7FromTime(turn.userTimestamp);
     traceId = turnRunId;
     parentDottedOrder = generateDottedOrderSegment(turn.userTimestamp, turnRunId);
     debug(`Creating new standalone turn run ${turnRunId}`);
@@ -12636,7 +12631,7 @@ async function traceTurn(options) {
   let lastEndTime = turn.userTimestamp;
   for (const llmCall of turn.llmCalls) {
     const assistantContent = formatContent(llmCall.content);
-    const assistantRunId = uuid7();
+    const assistantRunId = uuid7FromTime(llmCall.startTime);
     const assistantDottedOrderSegment = generateDottedOrderSegment(llmCall.startTime, assistantRunId);
     const assistantDottedOrder = `${parentDottedOrder}.${assistantDottedOrderSegment}`;
     const assistantRunTree = new RunTree({
@@ -12665,7 +12660,7 @@ async function traceTurn(options) {
       }
       const toolEndTime = toolCall.result?.timestamp ?? llmCall.endTime;
       const toolStartTime = llmCall.endTime <= toolEndTime ? llmCall.endTime : toolEndTime;
-      const toolRunId = uuid7();
+      const toolRunId = uuid7FromTime(toolStartTime);
       const toolDottedOrderSegment = generateDottedOrderSegment(toolStartTime, toolRunId);
       const toolDottedOrder = `${parentDottedOrder}.${toolDottedOrderSegment}`;
       const runTree2 = new RunTree({
@@ -12936,7 +12931,7 @@ async function tracePendingSubagents(options) {
   return openedAgentRunIds;
 }
 async function traceSubagentChain(opts) {
-  const subagentChainId = uuid7();
+  const subagentChainId = uuid7FromTime(opts.startTime);
   const subagentChainDottedOrder = `${opts.parentDottedOrder}.${generateDottedOrderSegment(opts.startTime, subagentChainId)}`;
   const runTree = new RunTree({
     client,

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -11888,11 +11888,6 @@ function _checkEndpointEnvUnset(parsed) {
   }
 }
 
-// node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/uuid.js
-function uuid7() {
-  return v7_default();
-}
-
 // node_modules/.pnpm/langsmith@0.7.11/node_modules/langsmith/dist/singletons/traceable.js
 var MockAsyncLocalStorage = class {
   getStore() {
@@ -12677,7 +12672,7 @@ async function traceTurn(options) {
     }
   } else {
     shouldCreateTurn = true;
-    turnRunId = uuid7();
+    turnRunId = uuid7FromTime(turn.userTimestamp);
     traceId = turnRunId;
     parentDottedOrder = generateDottedOrderSegment(turn.userTimestamp, turnRunId);
     debug(`Creating new standalone turn run ${turnRunId}`);
@@ -12715,7 +12710,7 @@ async function traceTurn(options) {
   let lastEndTime = turn.userTimestamp;
   for (const llmCall of turn.llmCalls) {
     const assistantContent = formatContent(llmCall.content);
-    const assistantRunId = uuid7();
+    const assistantRunId = uuid7FromTime(llmCall.startTime);
     const assistantDottedOrderSegment = generateDottedOrderSegment(llmCall.startTime, assistantRunId);
     const assistantDottedOrder = `${parentDottedOrder}.${assistantDottedOrderSegment}`;
     const assistantRunTree = new RunTree({
@@ -12744,7 +12739,7 @@ async function traceTurn(options) {
       }
       const toolEndTime = toolCall.result?.timestamp ?? llmCall.endTime;
       const toolStartTime = llmCall.endTime <= toolEndTime ? llmCall.endTime : toolEndTime;
-      const toolRunId = uuid7();
+      const toolRunId = uuid7FromTime(toolStartTime);
       const toolDottedOrderSegment = generateDottedOrderSegment(toolStartTime, toolRunId);
       const toolDottedOrder = `${parentDottedOrder}.${toolDottedOrderSegment}`;
       const runTree2 = new RunTree({
@@ -13101,7 +13096,7 @@ async function tracePendingSubagents(options) {
   return openedAgentRunIds;
 }
 async function traceSubagentChain(opts) {
-  const subagentChainId = uuid7();
+  const subagentChainId = uuid7FromTime(opts.startTime);
   const subagentChainDottedOrder = `${opts.parentDottedOrder}.${generateDottedOrderSegment(opts.startTime, subagentChainId)}`;
   const runTree = new RunTree({
     client,
@@ -13574,8 +13569,8 @@ async function main() {
     }
   }
   const turnNum = sessionState.turn_count + interruptedTurnsTraced + 1;
-  const runId = uuid7();
   const startTime = (/* @__PURE__ */ new Date()).toISOString();
+  const runId = uuid7FromTime(startTime);
   const segment = generateDottedOrderSegment(startTime, runId);
   let traceId;
   let parentRunId;

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -13275,7 +13275,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.2" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langsmith-claude-code-plugins",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Claude Code plugin for LangSmith tracing",
   "type": "module",
   "main": "dist/index.js",

--- a/src/hooks/post-compact.ts
+++ b/src/hooks/post-compact.ts
@@ -6,7 +6,7 @@
  * Creates a LangSmith run capturing the compaction event and summary.
  */
 
-import { RunTree, uuid7 } from "langsmith";
+import { RunTree, uuid7FromTime } from "langsmith";
 import { debug, error } from "../logger.js";
 import { initTracing, generateDottedOrderSegment, flushPendingTraces } from "../langsmith.js";
 import { loadState, atomicUpdateState, getSessionState } from "../state.js";
@@ -47,7 +47,7 @@ async function main(): Promise<void> {
     ? new Date(sessionState.compaction_start_time).toISOString()
     : endTime;
 
-  const runId = uuid7();
+  const runId = uuid7FromTime(startTime);
   const segment = generateDottedOrderSegment(startTime, runId);
 
   // Nest under the current turn's trace if one is active, otherwise standalone.

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -7,7 +7,7 @@
  * so SubagentStop can nest the subagent trace under it.
  */
 
-import { RunTree, uuid7 } from "langsmith";
+import { RunTree, uuid7FromTime } from "langsmith";
 import { debug, error } from "../logger.js";
 import { initTracing, generateDottedOrderSegment, flushPendingTraces } from "../langsmith.js";
 import { loadState, atomicUpdateState, getSessionState } from "../state.js";
@@ -68,8 +68,8 @@ async function main(): Promise<void> {
   // Generate run ID and dotted order for this tool.
   // Use PreToolUse's recorded start time if available (accurate wall-clock time
   // from before the tool ran), otherwise fall back to Date.now().
-  const toolRunId = uuid7();
   const startTime = sessionState.tool_start_times?.[input.tool_use_id] ?? Date.now();
+  const toolRunId = uuid7FromTime(startTime);
   const toolEndTime = Date.now();
   // Convert to ISO for RunTree (avoids internal timestamp mangling)
   const startTimeIso = new Date(startTime).toISOString();

--- a/src/hooks/user-prompt-submit.ts
+++ b/src/hooks/user-prompt-submit.ts
@@ -11,7 +11,7 @@
  * transcript before closing it with "User interrupt".
  */
 
-import { RunTree, uuid7 } from "langsmith";
+import { RunTree, uuid7FromTime } from "langsmith";
 import { debug, error } from "../logger.js";
 import {
   initTracing,
@@ -148,8 +148,8 @@ async function main(): Promise<void> {
 
   const turnNum = sessionState.turn_count + interruptedTurnsTraced + 1;
 
-  const runId = uuid7();
   const startTime = new Date().toISOString();
+  const runId = uuid7FromTime(startTime);
   const segment = generateDottedOrderSegment(startTime, runId);
 
   // Decide where this turn nests.

--- a/src/langsmith.test.ts
+++ b/src/langsmith.test.ts
@@ -5,13 +5,23 @@ import { ASSISTANT_RUN_NAME, USER_PROMPT_TURN_NAME } from "./constants.js";
 const mockCreateRun = vi.fn().mockResolvedValue(undefined);
 const mockUpdateRun = vi.fn().mockResolvedValue(undefined);
 const mockAwaitPendingTraceBatches = vi.fn().mockResolvedValue(undefined);
+const { mockUuid7FromTime } = vi.hoisted(() => ({
+  mockUuid7FromTime: vi.fn(),
+}));
+
+function timestampFromUuid7(uuid: string): number {
+  return Number.parseInt(uuid.replaceAll("-", "").slice(0, 12), 16);
+}
 
 // Track the last RunTree params for assertions
 let lastRunTreeParams: Record<string, unknown> | null = null;
 // Track all RunTree instances with their operations
 let allRunTreeInstances: Array<{ params: Record<string, unknown>; ops: string[] }> = [];
 
-vi.mock("langsmith", () => {
+vi.mock("langsmith", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("langsmith")>();
+  mockUuid7FromTime.mockImplementation(actual.uuid7FromTime);
+
   class MockClient {
     createRun = mockCreateRun;
     updateRun = mockUpdateRun;
@@ -47,7 +57,8 @@ vi.mock("langsmith", () => {
   return {
     RunTree: MockRunTree,
     Client: MockClient,
-    uuid7: () => `test-uuid-${Math.random().toString(36).slice(2, 15)}`,
+    uuid7: actual.uuid7,
+    uuid7FromTime: mockUuid7FromTime,
   };
 });
 
@@ -227,6 +238,7 @@ describe("traceTurn", () => {
     mockCreateRun.mockClear();
     mockUpdateRun.mockClear();
     mockAwaitPendingTraceBatches.mockClear();
+    mockUuid7FromTime.mockClear();
     allRunTreeInstances = [];
     initTracing("test-api-key", "https://test.api.com");
   });
@@ -280,6 +292,11 @@ describe("traceTurn", () => {
     expect(assistantUpdateArgs.extra.metadata.ls_provider).toBe("anthropic");
     expect(assistantUpdateArgs.extra.metadata.ls_model_name).toBe("claude-sonnet-4-5");
     expect(assistantUpdateArgs.extra.metadata.ls_invocation_params.model).toBe("claude-sonnet-4-5");
+
+    expect(timestampFromUuid7(turnCall.id)).toBe(Date.parse(turnCall.start_time));
+    expect(timestampFromUuid7(llmCall.id)).toBe(Date.parse(llmCall.start_time));
+    expect(mockUuid7FromTime).toHaveBeenNthCalledWith(1, turnCall.start_time);
+    expect(mockUuid7FromTime).toHaveBeenNthCalledWith(2, llmCall.start_time);
   });
 
   it("uses existing parentRunId and skips creating turn run", async () => {
@@ -390,6 +407,13 @@ describe("traceTurn", () => {
     const turnCall = mockCreateRun.mock.calls[0][0];
     const llmCall = mockCreateRun.mock.calls[1][0];
     const toolCall = mockCreateRun.mock.calls[2][0];
+
+    expect(timestampFromUuid7(turnCall.id)).toBe(Date.parse(turnCall.start_time));
+    expect(timestampFromUuid7(llmCall.id)).toBe(Date.parse(llmCall.start_time));
+    expect(timestampFromUuid7(toolCall.id)).toBe(Date.parse(toolCall.start_time));
+    expect(mockUuid7FromTime).toHaveBeenNthCalledWith(1, turnCall.start_time);
+    expect(mockUuid7FromTime).toHaveBeenNthCalledWith(2, llmCall.start_time);
+    expect(mockUuid7FromTime).toHaveBeenNthCalledWith(3, toolCall.start_time);
 
     // Tool is child of turn, not assistant
     expect(toolCall.parent_run_id).toBe(turnCall.id);

--- a/src/langsmith.test.ts
+++ b/src/langsmith.test.ts
@@ -57,7 +57,6 @@ vi.mock("langsmith", async (importOriginal) => {
   return {
     RunTree: MockRunTree,
     Client: MockClient,
-    uuid7: actual.uuid7,
     uuid7FromTime: mockUuid7FromTime,
   };
 });
@@ -1214,7 +1213,12 @@ describe("traceTurn", () => {
           endTime: "2025-01-01T00:00:02Z",
           toolCalls: [
             {
-              tool_use: { id: "tool-1", name: "Read", input: { file: "test.ts" } },
+              tool_use: {
+                type: "tool_use",
+                id: "tool-1",
+                name: "Read",
+                input: { file: "test.ts" },
+              },
               result: { content: "file contents", timestamp: "2025-01-01T00:00:03Z" },
             },
           ],

--- a/src/langsmith.ts
+++ b/src/langsmith.ts
@@ -6,7 +6,7 @@
  * serialization, retries, and auth automatically.
  */
 
-import { Client, RunTree, RunTreeConfig, uuid7 } from "langsmith";
+import { Client, RunTree, RunTreeConfig, uuid7FromTime } from "langsmith";
 import { createSecretAnonymizer } from "langsmith/anonymizer";
 import type { StringNodeRule } from "langsmith/anonymizer";
 import type { Turn, ContentBlock, Usage, OpenTurn, SessionState } from "./types.js";
@@ -234,7 +234,7 @@ export async function traceTurn(
   } else {
     // Create a new turn run for interrupted/standalone turns
     shouldCreateTurn = true;
-    turnRunId = uuid7();
+    turnRunId = uuid7FromTime(turn.userTimestamp);
     traceId = turnRunId; // This turn is its own trace root
 
     parentDottedOrder = generateDottedOrderSegment(turn.userTimestamp, turnRunId);
@@ -283,7 +283,7 @@ export async function traceTurn(
     const assistantContent = formatContent(llmCall.content);
 
     // Generate run ID for this LLM call
-    const assistantRunId = uuid7();
+    const assistantRunId = uuid7FromTime(llmCall.startTime);
     const assistantDottedOrderSegment = generateDottedOrderSegment(
       llmCall.startTime,
       assistantRunId,
@@ -328,7 +328,7 @@ export async function traceTurn(
       const toolStartTime = llmCall.endTime <= toolEndTime ? llmCall.endTime : toolEndTime;
 
       // Generate run ID for this tool
-      const toolRunId = uuid7();
+      const toolRunId = uuid7FromTime(toolStartTime);
       const toolDottedOrderSegment = generateDottedOrderSegment(toolStartTime, toolRunId);
       const toolDottedOrder = `${parentDottedOrder}.${toolDottedOrderSegment}`;
 
@@ -956,7 +956,7 @@ async function traceSubagentChain(opts: {
   turnId?: string;
   turnNumber?: number;
 }): Promise<void> {
-  const subagentChainId = uuid7();
+  const subagentChainId = uuid7FromTime(opts.startTime);
   const subagentChainDottedOrder = `${opts.parentDottedOrder}.${generateDottedOrderSegment(opts.startTime, subagentChainId)}`;
 
   const runTree = new RunTree({


### PR DESCRIPTION
Relying on `uuid7` can cause unintended consequences if the minting time differs from `start_time`, causing the run to not appear in LangSmith. 