### PR TITLE
feat: adds effort invocation params to traces [LSDK-417]

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langsmith-tracing",
   "description": "Traces Claude Code conversations to LangSmith, including subagent and tool executions",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": {
     "name": "LangChain"
   },

--- a/bundle/post-compact.js
+++ b/bundle/post-compact.js
@@ -12308,7 +12308,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.4" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/post-tool-use.js
+++ b/bundle/post-tool-use.js
@@ -12314,7 +12314,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.4" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/pre-compact.js
+++ b/bundle/pre-compact.js
@@ -104,7 +104,7 @@ import { readFileSync as readFileSync2 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.4" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/pre-tool-use.js
+++ b/bundle/pre-tool-use.js
@@ -104,7 +104,7 @@ import { readFileSync as readFileSync2 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.4" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -12312,6 +12312,8 @@ function mergeAssistantChunks(chunks) {
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage,
     // SSE usage is cumulative; last chunk has final totals.
+    // Top-level field; not every chunk (or CC version) carries it.
+    effort: chunks.find((c) => c.effort !== void 0)?.effort,
     startTime: first.timestamp,
     endTime: last.timestamp
   };
@@ -12385,6 +12387,7 @@ function groupIntoTurns(messages) {
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
+        effort: merged.effort,
         startTime: merged.startTime,
         endTime: merged.endTime,
         toolCalls
@@ -12759,7 +12762,10 @@ async function traceTurn(options) {
             ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
-              model: llmCall.model
+              model: llmCall.model,
+              // Omitted by older CC versions and SDK-launched sessions.
+              ...llmCall.effort !== void 0 ? { effort: llmCall.effort } : {},
+              ...llmCall.usage?.service_tier !== void 0 ? { service_tier: llmCall.usage.service_tier } : {}
             },
             usage_metadata: buildUsageMetadata(llmCall.usage),
             ...llmCall.synthetic ? { synthetic: true } : {}

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -13156,7 +13156,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.4" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/stop-failure.js
+++ b/bundle/stop-failure.js
@@ -12305,7 +12305,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.4" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -737,6 +737,8 @@ function mergeAssistantChunks(chunks) {
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage,
     // SSE usage is cumulative; last chunk has final totals.
+    // Top-level field; not every chunk (or CC version) carries it.
+    effort: chunks.find((c) => c.effort !== void 0)?.effort,
     startTime: first.timestamp,
     endTime: last.timestamp
   };
@@ -810,6 +812,7 @@ function groupIntoTurns(messages) {
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
+        effort: merged.effort,
         startTime: merged.startTime,
         endTime: merged.endTime,
         toolCalls
@@ -12789,7 +12792,10 @@ async function traceTurn(options) {
             ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
-              model: llmCall.model
+              model: llmCall.model,
+              // Omitted by older CC versions and SDK-launched sessions.
+              ...llmCall.effort !== void 0 ? { effort: llmCall.effort } : {},
+              ...llmCall.usage?.service_tier !== void 0 ? { service_tier: llmCall.usage.service_tier } : {}
             },
             usage_metadata: buildUsageMetadata(llmCall.usage),
             ...llmCall.synthetic ? { synthetic: true } : {}

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -13100,7 +13100,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.4" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/subagent-stop.js
+++ b/bundle/subagent-stop.js
@@ -12344,6 +12344,8 @@ function mergeAssistantChunks(chunks) {
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage,
     // SSE usage is cumulative; last chunk has final totals.
+    // Top-level field; not every chunk (or CC version) carries it.
+    effort: chunks.find((c) => c.effort !== void 0)?.effort,
     startTime: first.timestamp,
     endTime: last.timestamp
   };
@@ -12417,6 +12419,7 @@ function groupIntoTurns(messages) {
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
+        effort: merged.effort,
         startTime: merged.startTime,
         endTime: merged.endTime,
         toolCalls
@@ -12729,7 +12732,10 @@ async function traceTurn(options) {
             ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
-              model: llmCall.model
+              model: llmCall.model,
+              // Omitted by older CC versions and SDK-launched sessions.
+              ...llmCall.effort !== void 0 ? { effort: llmCall.effort } : {},
+              ...llmCall.usage?.service_tier !== void 0 ? { service_tier: llmCall.usage.service_tier } : {}
             },
             usage_metadata: buildUsageMetadata(llmCall.usage),
             ...llmCall.synthetic ? { synthetic: true } : {}

--- a/bundle/subagent-stop.js
+++ b/bundle/subagent-stop.js
@@ -13200,7 +13200,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.4" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -13281,7 +13281,7 @@ import { readFileSync as readFileSync5 } from "node:fs";
 import { userInfo } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
-var LS_INTEGRATION_VERSION = true ? "0.2.3" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
+var LS_INTEGRATION_VERSION = true ? "0.2.4" : process.env.CC_LANGSMITH_INTEGRATION_VERSION || void 0;
 var PROVIDER_HOSTS = {
   github: "github.com",
   gitlab: "gitlab.com",

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -12351,6 +12351,8 @@ function mergeAssistantChunks(chunks) {
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage,
     // SSE usage is cumulative; last chunk has final totals.
+    // Top-level field; not every chunk (or CC version) carries it.
+    effort: chunks.find((c) => c.effort !== void 0)?.effort,
     startTime: first.timestamp,
     endTime: last.timestamp
   };
@@ -12424,6 +12426,7 @@ function groupIntoTurns(messages) {
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
+        effort: merged.effort,
         startTime: merged.startTime,
         endTime: merged.endTime,
         toolCalls
@@ -12808,7 +12811,10 @@ async function traceTurn(options) {
             ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
-              model: llmCall.model
+              model: llmCall.model,
+              // Omitted by older CC versions and SDK-launched sessions.
+              ...llmCall.effort !== void 0 ? { effort: llmCall.effort } : {},
+              ...llmCall.usage?.service_tier !== void 0 ? { service_tier: llmCall.usage.service_tier } : {}
             },
             usage_metadata: buildUsageMetadata(llmCall.usage),
             ...llmCall.synthetic ? { synthetic: true } : {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langsmith-claude-code-plugins",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude Code plugin for LangSmith tracing",
   "type": "module",
   "main": "dist/index.js",

--- a/src/langsmith.test.ts
+++ b/src/langsmith.test.ts
@@ -290,12 +290,42 @@ describe("traceTurn", () => {
     const assistantUpdateArgs = mockUpdateRun.mock.calls[0][1];
     expect(assistantUpdateArgs.extra.metadata.ls_provider).toBe("anthropic");
     expect(assistantUpdateArgs.extra.metadata.ls_model_name).toBe("claude-sonnet-4-5");
-    expect(assistantUpdateArgs.extra.metadata.ls_invocation_params.model).toBe("claude-sonnet-4-5");
+    expect(assistantUpdateArgs.extra.metadata.ls_invocation_params).toEqual({
+      model: "claude-sonnet-4-5",
+    });
 
     expect(timestampFromUuid7(turnCall.id)).toBe(Date.parse(turnCall.start_time));
     expect(timestampFromUuid7(llmCall.id)).toBe(Date.parse(llmCall.start_time));
     expect(mockUuid7FromTime).toHaveBeenNthCalledWith(1, turnCall.start_time);
     expect(mockUuid7FromTime).toHaveBeenNthCalledWith(2, llmCall.start_time);
+  });
+
+  it("stamps effort and service_tier into ls_invocation_params when present", async () => {
+    const turn: Turn = {
+      userContent: "Hello",
+      userTimestamp: "2025-01-01T00:00:00Z",
+      llmCalls: [
+        {
+          content: [{ type: "text", text: "Hi there!" }],
+          model: "claude-opus-5",
+          usage: { input_tokens: 10, output_tokens: 5, service_tier: "standard" },
+          effort: "high",
+          startTime: "2025-01-01T00:00:01Z",
+          endTime: "2025-01-01T00:00:02Z",
+          toolCalls: [],
+        },
+      ],
+      isComplete: true,
+    };
+
+    await traceTurn({ turn, sessionId: "session-123", turnNum: 1, project: "test-project" });
+
+    const assistantUpdateArgs = mockUpdateRun.mock.calls[0][1];
+    expect(assistantUpdateArgs.extra.metadata.ls_invocation_params).toEqual({
+      model: "claude-opus-5",
+      effort: "high",
+      service_tier: "standard",
+    });
   });
 
   it("uses existing parentRunId and skips creating turn run", async () => {

--- a/src/langsmith.ts
+++ b/src/langsmith.ts
@@ -407,6 +407,11 @@ export async function traceTurn(
             ls_model_name: llmCall.model,
             ls_invocation_params: {
               model: llmCall.model,
+              // Omitted by older CC versions and SDK-launched sessions.
+              ...(llmCall.effort !== undefined ? { effort: llmCall.effort } : {}),
+              ...(llmCall.usage?.service_tier !== undefined
+                ? { service_tier: llmCall.usage.service_tier }
+                : {}),
             },
             usage_metadata: buildUsageMetadata(llmCall.usage),
             ...(llmCall.synthetic ? { synthetic: true } : {}),

--- a/src/transcript.test.ts
+++ b/src/transcript.test.ts
@@ -51,6 +51,7 @@ function makeAssistant(
     toolUses?: Array<{ id: string; name: string; input: Record<string, unknown> }>;
     usage?: { input_tokens: number; output_tokens: number };
     stop_reason?: string | null;
+    effort?: string;
   } = {},
 ): AssistantMessage {
   const content: AssistantMessage["message"]["content"] = [{ type: "text" as const, text }];
@@ -70,6 +71,7 @@ function makeAssistant(
       stop_reason: opts.stop_reason,
     },
     timestamp: opts.ts ?? "2025-01-01T00:00:01Z",
+    effort: opts.effort,
   };
 }
 
@@ -440,6 +442,31 @@ describe("groupIntoTurns", () => {
     ];
     const turns = groupIntoTurns(messages);
     expect(turns[0].llmCalls[0].model).toBe("claude-sonnet-4-5");
+  });
+
+  it("captures top-level effort on the LLM call", () => {
+    const messages: TranscriptMessage[] = [
+      makeUser("Hi"),
+      makeAssistant("msg_1", "Hello", { effort: "high" }),
+    ];
+    const turns = groupIntoTurns(messages);
+    expect(turns[0].llmCalls[0].effort).toBe("high");
+  });
+
+  it("leaves effort undefined when the transcript omits it", () => {
+    const messages: TranscriptMessage[] = [makeUser("Hi"), makeAssistant("msg_1", "Hello")];
+    const turns = groupIntoTurns(messages);
+    expect(turns[0].llmCalls[0].effort).toBeUndefined();
+  });
+
+  it("picks up effort from any streaming chunk of a message", () => {
+    const messages: TranscriptMessage[] = [
+      makeUser("Hi"),
+      makeAssistant("msg_1", "Hel", { ts: "2025-01-01T00:00:01Z" }),
+      makeAssistant("msg_1", "lo", { ts: "2025-01-01T00:00:02Z", effort: "low" }),
+    ];
+    const turns = groupIntoTurns(messages);
+    expect(turns[0].llmCalls[0].effort).toBe("low");
   });
 
   it("returns empty array for no messages", () => {

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -247,6 +247,7 @@ function mergeAssistantChunks(chunks: AssistantMessage[]): {
   content: ContentBlock[];
   model: string;
   usage: Usage;
+  effort?: string;
   startTime: string;
   endTime: string;
 } {
@@ -265,6 +266,8 @@ function mergeAssistantChunks(chunks: AssistantMessage[]): {
     content: merged,
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage, // SSE usage is cumulative; last chunk has final totals.
+    // Top-level field; not every chunk (or CC version) carries it.
+    effort: chunks.find((c) => c.effort !== undefined)?.effort,
     startTime: first.timestamp,
     endTime: last.timestamp,
   };
@@ -382,6 +385,7 @@ export function groupIntoTurns(messages: TranscriptMessage[]): Turn[] {
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
+        effort: merged.effort,
         startTime: merged.startTime,
         endTime: merged.endTime,
         toolCalls,

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export interface Usage {
   output_tokens: number;
   cache_read_input_tokens?: number;
   cache_creation_input_tokens?: number;
+  service_tier?: string;
 }
 
 /** A user message (human input) in the transcript. */
@@ -112,6 +113,8 @@ export interface AssistantMessage {
   };
   timestamp: string;
   promptId?: string;
+  /** Reasoning effort, top-level (not in `message`). Added in CC 2.1.212. */
+  effort?: string;
 }
 
 export type TranscriptMessage = UserMessage | ToolResultMessage | AssistantMessage;
@@ -141,6 +144,8 @@ export interface LLMCall {
   startTime: string;
   /** Timestamp of last chunk (end time). */
   endTime: string;
+  /** Reasoning effort, if the transcript recorded one. */
+  effort?: string;
   /** Tool calls made in this response. */
   toolCalls: ToolCall[];
   /** True if this LLM call was synthesized (not from the transcript). */


### PR DESCRIPTION
view trace: [here](https://smith.langchain.com/o/ebbaf2eb-769b-4505-aca2-d11de10372a4/projects/p/fea38898-1f1f-440d-841d-4798bc4a5d29?timeModel=%7B%22duration%22%3A%2230d%22%7D&peek=019fb4e9-5cfb-7000-8000-039521ed4ef0&start_time=2026-07-30T21%3A23%3A40.411Z&peek_project=fea38898-1f1f-440d-841d-4798bc4a5d29&peekedConversationId=8d7ac9d2-75f7-412b-85f3-6bed672d3e66&run_id=019fb4e9-6c14-7000-8000-0284c7cbd584&conversationTab=trace&scroll_to=metadata&peeked_trace=019fb4e9-5cfb-7000-8000-039521ed4ef0&trace_id=019fb4e9-5cfb-7000-8000-039521ed4ef0)

to summarize: 
surfaces per-call effort setting on LLM runs in traces. CC newly writes effort as a top-level field on assistant transcript entries, but AssistantMessage in types.ts only modeled nested message payload, so we dropped the field. This threads effort through the parses and merge step into ls_invocation_params, along with service_tier from usage (written only when present - back compat). 

Also: bumps release (v0.2.3 to v0.2.4)
