### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

- add weekly Dependabot updates for the root pnpm/npm dependency set
- add weekly Dependabot updates for GitHub Actions
- cap each ecosystem at 10 open pull requests

## Validation

- parsed `.github/dependabot.yml` with Ruby YAML
- ran `git diff --check`
- confirmed the change is limited to `.github/dependabot.yml`
