### PR TITLE
feat: Add current-session LangSmith trace command

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ Tool runs include the tool name, inputs, and output content. Skill tool runs add
 
 Interrupted turns (where the user cancels mid-response) are marked with status `"interrupted"` in LangSmith.
 
+## Opening the current session in LangSmith
+
+Run `/langsmith-tracing:trace` to get a link to this conversation's trace. It does
+not start a model turn or change any settings. When you trace to several projects,
+you get one labelled link per project.
+
+- A new thread is empty until a traced prompt finishes uploading.
+- Changing projects does not move older traces.
+- These are not public share links; recipients need access to the project.
+- If the lookup fails, search LangSmith for the session ID it prints.
+
 ## Muting a thread
 
 Muting is off by default unless configured below. With tracing enabled, use these argument-free plugin commands:

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -13050,6 +13050,8 @@ function parseTracingCommand(prompt) {
     return "mute";
   if (prompt === "/langsmith-tracing:unmute")
     return "unmute";
+  if (prompt === "/langsmith-tracing:trace")
+    return "trace";
   return void 0;
 }
 async function setThreadTracingMode(stateFilePath, sessionId, mode) {
@@ -15058,6 +15060,48 @@ function readStdin() {
   });
 }
 
+// dist/thread-link.js
+var LOOKUP_TIMEOUT_MS = 4e3;
+async function describeThreadLinks(config, sessionId) {
+  if (!config.enabled) {
+    return "LangSmith tracing is disabled. Enable it and send a prompt first.";
+  }
+  const destinations = config.replicas?.length ? config.replicas : [{}];
+  const links = await Promise.all(destinations.map(async (replica) => {
+    const destination = Array.isArray(replica) ? { projectName: replica[0] } : replica;
+    const projectName = destination.projectName ?? config.project;
+    const apiKey = destination.apiKey ?? config.apiKey;
+    if (!apiKey)
+      return `${projectName}: No LangSmith API key configured for this destination.`;
+    try {
+      const client2 = new Client({
+        apiKey,
+        apiUrl: destination.apiUrl ?? config.apiBaseUrl,
+        workspaceId: destination.workspaceId,
+        timeout_ms: LOOKUP_TIMEOUT_MS,
+        callerOptions: {
+          // The SDK ignores maxRetries on reads. Throwing here is what stops the retries.
+          onFailedResponseHook: async () => {
+            throw new Error("Thread link lookup failed");
+          }
+        }
+      });
+      const project = await client2.readProject({ projectName });
+      const url = new URL(client2.getHostUrl());
+      const path3 = ["o", project.tenant_id, "projects", "p", project.id, "t", sessionId];
+      url.pathname = `${url.pathname.replace(/\/$/, "")}/${path3.map(encodeURIComponent).join("/")}`;
+      return `${projectName}: ${url.href}`;
+    } catch {
+      return `${projectName}: Could not resolve the thread link. Check access and connectivity, then retry.`;
+    }
+  }));
+  return [
+    ...links,
+    `Session ID: ${sessionId}`,
+    "If a thread is empty, send a traced prompt and allow time for uploads."
+  ].join("\n");
+}
+
 // dist/hooks/user-prompt-submit.js
 var KILLED_NOTIFICATION_STATUS = "killed";
 async function main() {
@@ -15068,18 +15112,22 @@ async function main() {
     let reason;
     try {
       const commandConfig = loadConfig({ cwd: input.cwd });
-      const mode = command === "mute" ? "metadata" : "full";
-      const result = await setThreadTracingMode(commandConfig.stateFilePath, input.session_id, mode);
-      reason = `Thread tracing ${command === "mute" ? "muted (metadata-only)" : "unmuted (full content)"}. Preference saved for the next turn; the current turn is unchanged.`;
-      if (result?.warning)
-        reason += ` Warning: ${result.warning}.`;
-      if (!commandConfig.enabled) {
-        reason += " Master tracing is disabled; this preference does not enable it.";
-      } else if (!commandConfig.apiKey && (!commandConfig.replicas || commandConfig.replicas.length === 0)) {
-        reason += " Tracing remains inactive until credentials are configured.";
+      if (command === "trace") {
+        reason = await describeThreadLinks(commandConfig, input.session_id);
+      } else {
+        const mode = command === "mute" ? "metadata" : "full";
+        const result = await setThreadTracingMode(commandConfig.stateFilePath, input.session_id, mode);
+        reason = `Thread tracing ${command === "mute" ? "muted (metadata-only)" : "unmuted (full content)"}. Preference saved for the next turn; the current turn is unchanged.`;
+        if (result?.warning)
+          reason += ` Warning: ${result.warning}.`;
+        if (!commandConfig.enabled) {
+          reason += " Master tracing is disabled; this preference does not enable it.";
+        } else if (!commandConfig.apiKey && (!commandConfig.replicas || commandConfig.replicas.length === 0)) {
+          reason += " Tracing remains inactive until credentials are configured.";
+        }
       }
     } catch (err) {
-      reason = `Could not ${command} thread tracing: ${err instanceof Error ? err.message : String(err)}. Tracing may still be enabled. Command blocked; no model turn was started.`;
+      reason = command === "trace" ? `Could not run the trace command. Session ID: ${input.session_id}. No tracing settings were changed.` : `Could not ${command} thread tracing: ${err instanceof Error ? err.message : String(err)}. Tracing may still be enabled. Command blocked; no model turn was started.`;
     }
     try {
       console.log(JSON.stringify({ decision: "block", reason }));

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -15062,17 +15062,26 @@ function readStdin() {
 
 // dist/thread-link.js
 var LOOKUP_TIMEOUT_MS = 4e3;
+function terminalLink(url) {
+  const OSC8 = "\x1B]8;;";
+  const BEL = "\x07";
+  return `${OSC8}${url}${BEL}${url}${OSC8}${BEL}`;
+}
 async function describeThreadLinks(config, sessionId) {
   if (!config.enabled) {
     return "LangSmith tracing is disabled. Enable it and send a prompt first.";
   }
   const destinations = config.replicas?.length ? config.replicas : [{}];
-  const links = await Promise.all(destinations.map(async (replica) => {
+  const results = await Promise.all(destinations.map(async (replica) => {
     const destination = Array.isArray(replica) ? { projectName: replica[0] } : replica;
     const projectName = destination.projectName ?? config.project;
     const apiKey = destination.apiKey ?? config.apiKey;
-    if (!apiKey)
-      return `${projectName}: No LangSmith API key configured for this destination.`;
+    if (!apiKey) {
+      return {
+        resolved: false,
+        line: `${projectName}: No LangSmith API key configured for this destination.`
+      };
+    }
     try {
       const client2 = new Client({
         apiKey,
@@ -15090,16 +15099,18 @@ async function describeThreadLinks(config, sessionId) {
       const url = new URL(client2.getHostUrl());
       const path3 = ["o", project.tenant_id, "projects", "p", project.id, "t", sessionId];
       url.pathname = `${url.pathname.replace(/\/$/, "")}/${path3.map(encodeURIComponent).join("/")}`;
-      return `${projectName}: ${url.href}`;
+      return { resolved: true, line: `${projectName}: ${terminalLink(url.href)}` };
     } catch {
-      return `${projectName}: Could not resolve the thread link. Check access and connectivity, then retry.`;
+      return {
+        resolved: false,
+        line: `${projectName}: Could not resolve the thread link. Check access and connectivity, then retry.`
+      };
     }
   }));
-  return [
-    ...links,
-    `Session ID: ${sessionId}`,
-    "If a thread is empty, send a traced prompt and allow time for uploads."
-  ].join("\n");
+  const lines = results.map((result) => result.line);
+  if (results.some((result) => !result.resolved))
+    lines.push(`Session ID: ${sessionId}`);
+  return lines.join("\n");
 }
 
 // dist/hooks/user-prompt-submit.js

--- a/commands/trace.md
+++ b/commands/trace.md
@@ -1,0 +1,6 @@
+---
+description: Show the current session's thread link in LangSmith
+disable-model-invocation: true
+---
+
+/langsmith-tracing:trace

--- a/src/hooks/user-prompt-submit.ts
+++ b/src/hooks/user-prompt-submit.ts
@@ -33,6 +33,7 @@ import { USER_PROMPT_TURN_NAME } from "../constants.js";
 import { codingAgentMetadata } from "../metadata.js";
 import { createRunTree } from "../privacy.js";
 import { loadConfig } from "../config.js";
+import { describeThreadLinks } from "../thread-link.js";
 import {
   parseTracingCommand,
   setThreadTracingMode,
@@ -71,25 +72,32 @@ async function main(): Promise<void> {
     let reason: string;
     try {
       const commandConfig = loadConfig({ cwd: input.cwd });
-      const mode = command === "mute" ? "metadata" : "full";
-      const result = await setThreadTracingMode(
-        commandConfig.stateFilePath,
-        input.session_id,
-        mode,
-      );
-      reason = `Thread tracing ${command === "mute" ? "muted (metadata-only)" : "unmuted (full content)"}. Preference saved for the next turn; the current turn is unchanged.`;
-      // Filesystem warnings stay in this local, blocked response, never tracing.
-      if (result?.warning) reason += ` Warning: ${result.warning}.`;
-      if (!commandConfig.enabled) {
-        reason += " Master tracing is disabled; this preference does not enable it.";
-      } else if (
-        !commandConfig.apiKey &&
-        (!commandConfig.replicas || commandConfig.replicas.length === 0)
-      ) {
-        reason += " Tracing remains inactive until credentials are configured.";
+      if (command === "trace") {
+        reason = await describeThreadLinks(commandConfig, input.session_id);
+      } else {
+        const mode = command === "mute" ? "metadata" : "full";
+        const result = await setThreadTracingMode(
+          commandConfig.stateFilePath,
+          input.session_id,
+          mode,
+        );
+        reason = `Thread tracing ${command === "mute" ? "muted (metadata-only)" : "unmuted (full content)"}. Preference saved for the next turn; the current turn is unchanged.`;
+        // Filesystem warnings stay in this local, blocked response, never tracing.
+        if (result?.warning) reason += ` Warning: ${result.warning}.`;
+        if (!commandConfig.enabled) {
+          reason += " Master tracing is disabled; this preference does not enable it.";
+        } else if (
+          !commandConfig.apiKey &&
+          (!commandConfig.replicas || commandConfig.replicas.length === 0)
+        ) {
+          reason += " Tracing remains inactive until credentials are configured.";
+        }
       }
     } catch (err) {
-      reason = `Could not ${command} thread tracing: ${err instanceof Error ? err.message : String(err)}. Tracing may still be enabled. Command blocked; no model turn was started.`;
+      reason =
+        command === "trace"
+          ? `Could not run the trace command. Session ID: ${input.session_id}. No tracing settings were changed.`
+          : `Could not ${command} thread tracing: ${err instanceof Error ? err.message : String(err)}. Tracing may still be enabled. Command blocked; no model turn was started.`;
     }
     try {
       console.log(JSON.stringify({ decision: "block", reason }));

--- a/src/thread-link.test.ts
+++ b/src/thread-link.test.ts
@@ -33,9 +33,9 @@ describe("thread links", () => {
       { ...config, replicas: [["other", undefined]] },
       "session-b",
     );
-    expect(first).toContain(
-      "https://smith.langchain.com/o/workspace-id/projects/p/project-id/t/session-a",
-    );
+    // Resolved URLs carry an OSC 8 hyperlink.
+    const link = "https://smith.langchain.com/o/workspace-id/projects/p/project-id/t/session-a";
+    expect(first).toBe(`example: \u001b]8;;${link}\u0007${link}\u001b]8;;\u0007`);
     expect(second).toContain("/t/session-b");
     expect(second).not.toContain("session-a");
     expect(String(fetchMock.mock.calls[0][0])).toContain("name=example");
@@ -80,8 +80,8 @@ describe("thread links", () => {
       },
       "session",
     );
-    expect(output).toContain("us-project: https://smith.langchain.com/");
-    expect(output).toContain("eu-project: https://eu.smith.langchain.com/");
+    expect(output).toContain("us-project: \u001b]8;;https://smith.langchain.com/");
+    expect(output).toContain("eu-project: \u001b]8;;https://eu.smith.langchain.com/");
     expect(output).not.toContain("example:");
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[1][1]?.headers).toMatchObject({
@@ -97,7 +97,7 @@ describe("thread links", () => {
       "session",
     );
     expect(output).toContain("bad: Could not resolve");
-    expect(output).toContain("good: https://smith.langchain.com/");
+    expect(output).toContain("good: \u001b]8;;https://smith.langchain.com/");
     expect(output).toContain("Session ID: session");
     expect(output).not.toContain("PRIVATE_DETAILS");
     expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/src/thread-link.test.ts
+++ b/src/thread-link.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "./config.js";
+import { describeThreadLinks, LOOKUP_TIMEOUT_MS } from "./thread-link.js";
+
+// Exercise the actual SDK URL handling and requests; only HTTP is replaced.
+const fetchMock = vi.fn<typeof fetch>();
+const config = {
+  enabled: true,
+  apiKey: "test",
+  apiBaseUrl: "https://api.smith.langchain.com",
+  project: "example",
+} as Config;
+
+beforeEach(() => {
+  fetchMock
+    .mockReset()
+    .mockImplementation(async () =>
+      Response.json([{ id: "project-id", tenant_id: "workspace-id" }]),
+    );
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("thread links", () => {
+  it("resolves each call from the passed session and config, not env or cached state", async () => {
+    vi.stubEnv("TRACE_TO_LANGSMITH", "false"); // Use resolved config, not a second env check.
+    const first = await describeThreadLinks(config, "session-a");
+    const second = await describeThreadLinks(
+      { ...config, replicas: [["other", undefined]] },
+      "session-b",
+    );
+    expect(first).toContain(
+      "https://smith.langchain.com/o/workspace-id/projects/p/project-id/t/session-a",
+    );
+    expect(second).toContain("/t/session-b");
+    expect(second).not.toContain("session-a");
+    expect(String(fetchMock.mock.calls[0][0])).toContain("name=example");
+    expect(String(fetchMock.mock.calls[1][0])).toContain("name=other");
+  });
+
+  it("preserves self-hosted URL prefixes and encodes the session ID", async () => {
+    const output = await describeThreadLinks(
+      { ...config, apiBaseUrl: "https://company.example/langsmith/api/v1" },
+      "session/with?#characters",
+    );
+    expect(output).toContain(
+      "https://company.example/langsmith/o/workspace-id/projects/p/project-id/t/session%2Fwith%3F%23characters",
+    );
+  });
+
+  it.each([
+    [{ ...config, enabled: false }, "session", "disabled"],
+    [{ ...config, apiKey: "" }, "session", "No LangSmith API key"],
+  ] as const)(
+    "handles unavailable tracing without requests",
+    async (settings, session, message) => {
+      expect(await describeThreadLinks(settings, session)).toContain(message);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("uses replica-only credentials and labels each destination instead of linking the primary", async () => {
+    const output = await describeThreadLinks(
+      {
+        ...config,
+        apiKey: "",
+        replicas: [
+          { projectName: "us-project", apiKey: "test-us" },
+          {
+            projectName: "eu-project",
+            apiKey: "test-eu",
+            apiUrl: "https://eu.api.smith.langchain.com",
+            workspaceId: "eu-workspace",
+          },
+        ],
+      },
+      "session",
+    );
+    expect(output).toContain("us-project: https://smith.langchain.com/");
+    expect(output).toContain("eu-project: https://eu.smith.langchain.com/");
+    expect(output).not.toContain("example:");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][1]?.headers).toMatchObject({
+      "x-tenant-id": "eu-workspace",
+      "x-api-key": "test-eu",
+    });
+  });
+
+  it("keeps working links when another destination fails, without retries", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("PRIVATE_DETAILS", { status: 500 }));
+    const output = await describeThreadLinks(
+      { ...config, replicas: [{ projectName: "bad" }, { projectName: "good" }] },
+      "session",
+    );
+    expect(output).toContain("bad: Could not resolve");
+    expect(output).toContain("good: https://smith.langchain.com/");
+    expect(output).toContain("Session ID: session");
+    expect(output).not.toContain("PRIVATE_DETAILS");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels a stalled lookup and returns without retries", async () => {
+    // Shorten the SDK's real request abort signal, not the command's control flow.
+    const timeout = AbortSignal.timeout.bind(AbortSignal);
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation(() => timeout(20));
+    fetchMock.mockImplementation(
+      async (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init!.signal!.addEventListener("abort", () => reject(init!.signal!.reason), {
+            once: true,
+          });
+        }),
+    );
+    expect(await describeThreadLinks(config, "session")).toContain("Could not resolve");
+    expect(timeoutSpy).toHaveBeenCalledWith(LOOKUP_TIMEOUT_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/thread-link.ts
+++ b/src/thread-link.ts
@@ -5,6 +5,16 @@ import type { Config } from "./config.js";
 export const LOOKUP_TIMEOUT_MS = 4_000;
 
 /**
+ * OSC 8 hyperlink keeping a wrapped URL clickable. The URL is its own label, so
+ * terminals without OSC 8 ignore the escape and still show the full link.
+ */
+function terminalLink(url: string): string {
+  const OSC8 = "\u001b]8;;";
+  const BEL = "\u0007";
+  return `${OSC8}${url}${BEL}${url}${OSC8}${BEL}`;
+}
+
+/**
  * Builds the message shown to the user: one link per destination, plus any
  * failures. Looks up every time from the hook's session ID, so nothing is cached.
  */
@@ -15,12 +25,17 @@ export async function describeThreadLinks(config: Config, sessionId: string): Pr
 
   // Replicas replace the main project rather than adding to it, matching RunTree.postRun.
   const destinations = config.replicas?.length ? config.replicas : [{}];
-  const links = await Promise.all(
+  const results = await Promise.all(
     destinations.map(async (replica) => {
       const destination = Array.isArray(replica) ? { projectName: replica[0] } : replica;
       const projectName = destination.projectName ?? config.project;
       const apiKey = destination.apiKey ?? config.apiKey;
-      if (!apiKey) return `${projectName}: No LangSmith API key configured for this destination.`;
+      if (!apiKey) {
+        return {
+          resolved: false,
+          line: `${projectName}: No LangSmith API key configured for this destination.`,
+        };
+      }
 
       try {
         const client = new Client({
@@ -39,17 +54,19 @@ export async function describeThreadLinks(config: Config, sessionId: string): Pr
         const url = new URL(client.getHostUrl());
         const path = ["o", project.tenant_id, "projects", "p", project.id, "t", sessionId];
         url.pathname = `${url.pathname.replace(/\/$/, "")}/${path.map(encodeURIComponent).join("/")}`;
-        return `${projectName}: ${url.href}`;
+        return { resolved: true, line: `${projectName}: ${terminalLink(url.href)}` };
       } catch {
         // Drop the error: SDK messages can carry request details the user should not see.
-        return `${projectName}: Could not resolve the thread link. Check access and connectivity, then retry.`;
+        return {
+          resolved: false,
+          line: `${projectName}: Could not resolve the thread link. Check access and connectivity, then retry.`,
+        };
       }
     }),
   );
 
-  return [
-    ...links,
-    `Session ID: ${sessionId}`,
-    "If a thread is empty, send a traced prompt and allow time for uploads.",
-  ].join("\n");
+  const lines = results.map((result) => result.line);
+  // A resolved link already ends in the session ID.
+  if (results.some((result) => !result.resolved)) lines.push(`Session ID: ${sessionId}`);
+  return lines.join("\n");
 }

--- a/src/thread-link.ts
+++ b/src/thread-link.ts
@@ -1,0 +1,55 @@
+import { Client } from "langsmith";
+import type { Config } from "./config.js";
+
+/** Stops a slow destination from hanging the command. */
+export const LOOKUP_TIMEOUT_MS = 4_000;
+
+/**
+ * Builds the message shown to the user: one link per destination, plus any
+ * failures. Looks up every time from the hook's session ID, so nothing is cached.
+ */
+export async function describeThreadLinks(config: Config, sessionId: string): Promise<string> {
+  if (!config.enabled) {
+    return "LangSmith tracing is disabled. Enable it and send a prompt first.";
+  }
+
+  // Replicas replace the main project rather than adding to it, matching RunTree.postRun.
+  const destinations = config.replicas?.length ? config.replicas : [{}];
+  const links = await Promise.all(
+    destinations.map(async (replica) => {
+      const destination = Array.isArray(replica) ? { projectName: replica[0] } : replica;
+      const projectName = destination.projectName ?? config.project;
+      const apiKey = destination.apiKey ?? config.apiKey;
+      if (!apiKey) return `${projectName}: No LangSmith API key configured for this destination.`;
+
+      try {
+        const client = new Client({
+          apiKey,
+          apiUrl: destination.apiUrl ?? config.apiBaseUrl,
+          workspaceId: destination.workspaceId,
+          timeout_ms: LOOKUP_TIMEOUT_MS,
+          callerOptions: {
+            // The SDK ignores maxRetries on reads. Throwing here is what stops the retries.
+            onFailedResponseHook: async () => {
+              throw new Error("Thread link lookup failed");
+            },
+          },
+        });
+        const project = await client.readProject({ projectName });
+        const url = new URL(client.getHostUrl());
+        const path = ["o", project.tenant_id, "projects", "p", project.id, "t", sessionId];
+        url.pathname = `${url.pathname.replace(/\/$/, "")}/${path.map(encodeURIComponent).join("/")}`;
+        return `${projectName}: ${url.href}`;
+      } catch {
+        // Drop the error: SDK messages can carry request details the user should not see.
+        return `${projectName}: Could not resolve the thread link. Check access and connectivity, then retry.`;
+      }
+    }),
+  );
+
+  return [
+    ...links,
+    `Session ID: ${sessionId}`,
+    "If a thread is empty, send a traced prompt and allow time for uploads.",
+  ].join("\n");
+}

--- a/src/tracing-policy.test.ts
+++ b/src/tracing-policy.test.ts
@@ -32,10 +32,12 @@ const mocks = vi.hoisted(() => ({
   stdin: vi.fn(),
   tracing: vi.fn(),
   state: vi.fn(),
+  links: vi.fn(),
 }));
 vi.mock("node:fs/promises", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:fs/promises")>()),
 }));
+vi.mock("./thread-link.js", () => ({ describeThreadLinks: mocks.links }));
 vi.mock("./config.js", () => ({ loadConfig: mocks.config }));
 vi.mock("./utils/hook-init.js", () => ({ initHook: mocks.init, expandHome: (p: string) => p }));
 vi.mock("./utils/stdin.js", () => ({ readStdin: mocks.stdin }));
@@ -411,7 +413,7 @@ describe("standalone tracing preference", () => {
 });
 
 describe("exact command parser", () => {
-  it.each(["mute", "unmute"] as const)("recognizes %s", (cmd) => {
+  it.each(["mute", "unmute", "trace"] as const)("recognizes %s", (cmd) => {
     expect(parseTracingCommand(`/langsmith-tracing:${cmd}`)).toBe(cmd);
   });
   it.each([
@@ -424,6 +426,8 @@ describe("exact command parser", () => {
     "/langsmith-tracing:MUTE",
     "please /langsmith-tracing:mute",
     "/langsmith-tracing:muted",
+    "/langsmith-tracing:trace now",
+    "please /langsmith-tracing:trace",
   ])("does not handle %j", (prompt) => expect(parseTracingCommand(prompt)).toBeUndefined());
 });
 
@@ -454,6 +458,7 @@ describe("actual UserPromptSubmit command prefix", () => {
     mocks.config
       .mockReset()
       .mockReturnValue({ stateFilePath: state, apiKey: "test", enabled: false });
+    mocks.links.mockReset().mockResolvedValue("project: https://smith.langchain.com/example");
   });
 
   it.each(["mute", "unmute"] as const)(
@@ -471,29 +476,53 @@ describe("actual UserPromptSubmit command prefix", () => {
     },
   );
 
-  it.each(["mute", "unmute"] as const)(
+  it.each(["mute", "unmute", "trace"] as const)(
     "handles the actual %s command definition body without a model turn",
     async (command) => {
       const definition = readFileSync(
         new URL(`../commands/${command}.md`, import.meta.url),
         "utf8",
       );
-      const frontmatter = /^---\r?\n[\s\S]*?\r?\n---\r?\n/.exec(definition);
-      expect(frontmatter).not.toBeNull();
-      expect(frontmatter![0]).toContain("disable-model-invocation: true");
-      // Feed the complete Markdown body, not a hardcoded prompt. Strip only
-      // surrounding Markdown whitespace; explanatory prose must fail this test.
-      // This tests our definition/hook contract, not Claude Code's expansion order.
-      const prompt = definition.slice(frontmatter![0].length).trim();
+      const frontmatter = /^---\r?\n[\s\S]*?\r?\n---\r?\n/.exec(definition)!;
+      expect(frontmatter[0]).toContain("disable-model-invocation: true");
+      // Check the Markdown/hook contract; Claude Code's expansion order needs a live test.
+      const prompt = definition.slice(frontmatter[0].length).trim();
       expect(prompt).toBe(`/langsmith-tracing:${command}`);
-      await setThreadTracingMode(state, "session", command === "mute" ? "full" : "metadata");
       writeFileSync(state, "existing turn");
-      const reason = await submit(prompt);
-      expect(reason).toContain("for the next turn; the current turn is unchanged");
-      expect(getThreadTracingMode(state, "session")).toBe(command === "mute" ? "metadata" : "full");
+      await submit(prompt);
       expect(readFileSync(state, "utf8")).toBe("existing turn");
     },
   );
+
+  it("returns the resolved thread link without touching tracing preferences", async () => {
+    const reason = await submit("/langsmith-tracing:trace");
+    expect(reason).toContain("https://smith.langchain.com/example");
+    expect(mocks.config).toHaveBeenCalledWith({ cwd: dir });
+    expect(mocks.links).toHaveBeenCalledWith(mocks.config.mock.results[0].value, "session");
+    expect(existsSync(policy)).toBe(false);
+  });
+
+  it("blocks a failed trace command without exposing error details or changing preferences", async () => {
+    mocks.links.mockRejectedValue(new Error("PRIVATE_REQUEST_DETAILS"));
+    const reason = await submit("/langsmith-tracing:trace");
+    expect(reason).toContain("Session ID: session");
+    expect(reason).not.toContain("PRIVATE_REQUEST_DETAILS");
+    expect(existsSync(policy)).toBe(false);
+    expect(existsSync(state)).toBe(false);
+  });
+
+  it("does not resolve links for an ordinary prompt", async () => {
+    vi.resetModules();
+    mocks.stdin.mockResolvedValue({
+      prompt: "Explain /langsmith-tracing:trace",
+      cwd: dir,
+      session_id: "session",
+    });
+    mocks.init.mockReturnValue(null);
+    await import("./hooks/user-prompt-submit.js");
+    await vi.waitFor(() => expect(mocks.init).toHaveBeenCalledWith(dir));
+    expect(mocks.links).not.toHaveBeenCalled();
+  });
 
   it.each(postcommitFaults)("reports saved, not failed, after %s failure", async (fault) => {
     await setThreadTracingMode(state, "session", "metadata");

--- a/src/tracing-policy.ts
+++ b/src/tracing-policy.ts
@@ -70,9 +70,10 @@ export function getThreadTracingMode(
 }
 
 /** Exact, argument-free commands only; ordinary prompts are never interpreted. */
-export function parseTracingCommand(prompt: string): "mute" | "unmute" | undefined {
+export function parseTracingCommand(prompt: string): "mute" | "unmute" | "trace" | undefined {
   if (prompt === "/langsmith-tracing:mute") return "mute";
   if (prompt === "/langsmith-tracing:unmute") return "unmute";
+  if (prompt === "/langsmith-tracing:trace") return "trace";
   return undefined;
 }
 


### PR DESCRIPTION
What:

- Add `/langsmith-tracing:trace` which prints a link to the current session's trace in LangSmith
- Resolves the link from the session ID each time so nothing is cached and resumed sessions work
- Blocks the prompt like `mute`/`unmute` so no model turn and no cost
- Review `src/hooks/user-prompt-submit.ts` with `git diff -w`. It's mostly re-indentation (+9/-1 without it)

Why:

- [LSDK-316](https://linear.app/langchain/issue/LSDK-316/add-a-langsmith-trace-command-for-claude-code): today you have to find the session ID and search for it by hand

## Test Plan

- [x] `pnpm test` (1677), `pnpm build`, `oxlint`, `oxfmt` pass; `bundle/` regenerates byte-identical
- [x] End-to-end on a local LangSmith: ran the command in a real session, link opened that session's thread
- [x] Real CLI, 5 sessions with HTTP mocked: separate sessions in one folder, file config, tracing disabled, no credentials, partial replica outage
- [x] Ran the command against LangSmith dev from a real terminal session and confirmed the [link](https://dev.smith.langchain.com/o/d6684905-655c-429b-bd14-ba302d94c03b/projects/p/9ce8e851-fe00-43c9-9b3d-2a98c43ca21c/t/7b7371b9-95ba-4c7f-95cc-124ed69e6655) opens that thread




