### PR TITLE
feat: Surface effort and service_tier in LLM invocation params

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ With full tracing (the default), each LLM run includes:
 
 - **Inputs**: accumulated conversation messages
 - **Outputs**: assistant response content
-- **Metadata**: `ls_provider: "anthropic"`, `ls_model_name`, `ls_invocation_params` (model, stop reason), token usage
+- **Metadata**: `ls_provider: "anthropic"`, `ls_model_name`, `ls_invocation_params` (model, plus `effort`/`service_tier` when the transcript records them), token usage
 
 In full mode, all runs (LLM, tool, turn, subagent) automatically include identity metadata so you can attribute traces in LangSmith:
 

--- a/bundle/session-end.js
+++ b/bundle/session-end.js
@@ -13408,6 +13408,8 @@ function mergeAssistantChunks(chunks) {
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage,
     // SSE usage is cumulative; last chunk has final totals.
+    effort: chunks.find((c) => c.effort)?.effort,
+    // Only some chunks carry effort; take the first.
     startTime: first.timestamp,
     endTime: last.timestamp
   };
@@ -13481,6 +13483,7 @@ function groupIntoTurns(messages) {
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
+        effort: merged.effort,
         startTime: merged.startTime,
         endTime: merged.endTime,
         toolCalls
@@ -13995,7 +13998,9 @@ async function traceTurn(options) {
             ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
-              model: llmCall.model
+              model: llmCall.model,
+              ...llmCall.effort ? { effort: llmCall.effort } : {},
+              ...llmCall.usage.service_tier ? { service_tier: llmCall.usage.service_tier } : {}
             },
             usage_metadata: buildUsageMetadata(llmCall.usage),
             ...llmCall.synthetic ? { synthetic: true } : {}

--- a/bundle/stop.js
+++ b/bundle/stop.js
@@ -798,6 +798,8 @@ function mergeAssistantChunks(chunks) {
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage,
     // SSE usage is cumulative; last chunk has final totals.
+    effort: chunks.find((c) => c.effort)?.effort,
+    // Only some chunks carry effort; take the first.
     startTime: first.timestamp,
     endTime: last.timestamp
   };
@@ -871,6 +873,7 @@ function groupIntoTurns(messages) {
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
+        effort: merged.effort,
         startTime: merged.startTime,
         endTime: merged.endTime,
         toolCalls
@@ -14040,7 +14043,9 @@ async function traceTurn(options) {
             ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
-              model: llmCall.model
+              model: llmCall.model,
+              ...llmCall.effort ? { effort: llmCall.effort } : {},
+              ...llmCall.usage.service_tier ? { service_tier: llmCall.usage.service_tier } : {}
             },
             usage_metadata: buildUsageMetadata(llmCall.usage),
             ...llmCall.synthetic ? { synthetic: true } : {}
@@ -14925,6 +14930,9 @@ async function main() {
       lastTurn.llmCalls.push({
         content: [{ type: "text", text: input.last_assistant_message }],
         model: lastLlm.model,
+        // A request setting, so it carries over like the model. service_tier is a
+        // response value with no reading for this call, so it stays absent.
+        effort: lastLlm.effort,
         usage: { input_tokens: 0, output_tokens: 0 },
         startTime: syntheticStart,
         endTime: syntheticEnd,

--- a/bundle/subagent-stop.js
+++ b/bundle/subagent-stop.js
@@ -13437,6 +13437,8 @@ function mergeAssistantChunks(chunks) {
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage,
     // SSE usage is cumulative; last chunk has final totals.
+    effort: chunks.find((c) => c.effort)?.effort,
+    // Only some chunks carry effort; take the first.
     startTime: first.timestamp,
     endTime: last.timestamp
   };
@@ -13510,6 +13512,7 @@ function groupIntoTurns(messages) {
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
+        effort: merged.effort,
         startTime: merged.startTime,
         endTime: merged.endTime,
         toolCalls
@@ -13962,7 +13965,9 @@ async function traceTurn(options) {
             ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
-              model: llmCall.model
+              model: llmCall.model,
+              ...llmCall.effort ? { effort: llmCall.effort } : {},
+              ...llmCall.usage.service_tier ? { service_tier: llmCall.usage.service_tier } : {}
             },
             usage_metadata: buildUsageMetadata(llmCall.usage),
             ...llmCall.synthetic ? { synthetic: true } : {}

--- a/bundle/user-prompt-submit.js
+++ b/bundle/user-prompt-submit.js
@@ -13522,6 +13522,8 @@ function mergeAssistantChunks(chunks) {
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage,
     // SSE usage is cumulative; last chunk has final totals.
+    effort: chunks.find((c) => c.effort)?.effort,
+    // Only some chunks carry effort; take the first.
     startTime: first.timestamp,
     endTime: last.timestamp
   };
@@ -13595,6 +13597,7 @@ function groupIntoTurns(messages) {
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
+        effort: merged.effort,
         startTime: merged.startTime,
         endTime: merged.endTime,
         toolCalls
@@ -14134,7 +14137,9 @@ async function traceTurn(options) {
             ls_provider: resolveProvider(llmCall.model),
             ls_model_name: llmCall.model,
             ls_invocation_params: {
-              model: llmCall.model
+              model: llmCall.model,
+              ...llmCall.effort ? { effort: llmCall.effort } : {},
+              ...llmCall.usage.service_tier ? { service_tier: llmCall.usage.service_tier } : {}
             },
             usage_metadata: buildUsageMetadata(llmCall.usage),
             ...llmCall.synthetic ? { synthetic: true } : {}

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -135,6 +135,9 @@ async function main(): Promise<void> {
       lastTurn.llmCalls.push({
         content: [{ type: "text", text: input.last_assistant_message }],
         model: lastLlm.model,
+        // A request setting, so it carries over like the model. service_tier is a
+        // response value with no reading for this call, so it stays absent.
+        effort: lastLlm.effort,
         usage: { input_tokens: 0, output_tokens: 0 },
         startTime: syntheticStart,
         endTime: syntheticEnd,

--- a/src/langsmith.test.ts
+++ b/src/langsmith.test.ts
@@ -290,13 +290,47 @@ describe("traceTurn", () => {
     const assistantUpdateArgs = mockUpdateRun.mock.calls[0][1];
     expect(assistantUpdateArgs.extra.metadata.ls_provider).toBe("anthropic");
     expect(assistantUpdateArgs.extra.metadata.ls_model_name).toBe("claude-sonnet-4-5");
-    expect(assistantUpdateArgs.extra.metadata.ls_invocation_params.model).toBe("claude-sonnet-4-5");
+    expect(assistantUpdateArgs.extra.metadata.ls_invocation_params).toEqual({
+      model: "claude-sonnet-4-5",
+    });
 
     expect(timestampFromUuid7(turnCall.id)).toBe(Date.parse(turnCall.start_time));
     expect(timestampFromUuid7(llmCall.id)).toBe(Date.parse(llmCall.start_time));
     expect(mockUuid7FromTime).toHaveBeenNthCalledWith(1, turnCall.start_time);
     expect(mockUuid7FromTime).toHaveBeenNthCalledWith(2, llmCall.start_time);
   });
+
+  it.each([
+    ["keeps", "high", "standard", { effort: "high", service_tier: "standard" }],
+    ["drops empty and null", "", null, {}],
+  ] as const)(
+    "%s effort and service_tier in ls_invocation_params",
+    async (_, effort, tier, extra) => {
+      const turn: Turn = {
+        userContent: "Hello",
+        userTimestamp: "2025-01-01T00:00:00Z",
+        llmCalls: [
+          {
+            content: [{ type: "text", text: "Hi there!" }],
+            model: "claude-opus-5",
+            usage: { input_tokens: 10, output_tokens: 5, service_tier: tier },
+            effort,
+            startTime: "2025-01-01T00:00:01Z",
+            endTime: "2025-01-01T00:00:02Z",
+            toolCalls: [],
+          },
+        ],
+        isComplete: true,
+      };
+
+      await traceTurn({ turn, sessionId: "session-123", turnNum: 1, project: "test-project" });
+
+      expect(mockUpdateRun.mock.calls[0][1].extra.metadata.ls_invocation_params).toEqual({
+        model: "claude-opus-5",
+        ...extra,
+      });
+    },
+  );
 
   it("uses existing parentRunId and skips creating turn run", async () => {
     const turn: Turn = {

--- a/src/langsmith.ts
+++ b/src/langsmith.ts
@@ -437,6 +437,8 @@ export async function traceTurn(options: TraceTurnOptions): Promise<Record<strin
               ls_model_name: llmCall.model,
               ls_invocation_params: {
                 model: llmCall.model,
+                ...(llmCall.effort ? { effort: llmCall.effort } : {}),
+                ...(llmCall.usage.service_tier ? { service_tier: llmCall.usage.service_tier } : {}),
               },
               usage_metadata: buildUsageMetadata(llmCall.usage),
               ...(llmCall.synthetic ? { synthetic: true } : {}),

--- a/src/transcript.test.ts
+++ b/src/transcript.test.ts
@@ -49,8 +49,9 @@ function makeAssistant(
     model?: string;
     ts?: string;
     toolUses?: Array<{ id: string; name: string; input: Record<string, unknown> }>;
-    usage?: { input_tokens: number; output_tokens: number };
+    usage?: { input_tokens: number; output_tokens: number; service_tier?: string | null };
     stop_reason?: string | null;
+    effort?: string;
   } = {},
 ): AssistantMessage {
   const content: AssistantMessage["message"]["content"] = [{ type: "text" as const, text }];
@@ -70,6 +71,7 @@ function makeAssistant(
       stop_reason: opts.stop_reason,
     },
     timestamp: opts.ts ?? "2025-01-01T00:00:01Z",
+    effort: opts.effort,
   };
 }
 
@@ -398,6 +400,7 @@ describe("groupIntoTurns", () => {
       },
       {
         type: "assistant",
+        effort: "low",
         message: {
           id: "msg_stream",
           role: "assistant",
@@ -414,7 +417,7 @@ describe("groupIntoTurns", () => {
           role: "assistant",
           model: "claude-sonnet-4-5-20250929",
           content: [{ type: "text", text: "a time." }],
-          usage: { input_tokens: 10, output_tokens: 8 },
+          usage: { input_tokens: 10, output_tokens: 8, service_tier: "priority" },
         },
         timestamp: "2025-01-01T00:00:01.200Z",
       },
@@ -428,6 +431,9 @@ describe("groupIntoTurns", () => {
     expect(call.content).toEqual([{ type: "text", text: "Once upon a time." }]);
     // Usage from last chunk (cumulative)
     expect(call.usage.output_tokens).toBe(8);
+    expect(call.usage.service_tier).toBe("priority");
+    // Effort from the first chunk that carries it
+    expect(call.effort).toBe("low");
     // Times from first/last chunk
     expect(call.startTime).toBe("2025-01-01T00:00:01.000Z");
     expect(call.endTime).toBe("2025-01-01T00:00:01.200Z");
@@ -440,6 +446,17 @@ describe("groupIntoTurns", () => {
     ];
     const turns = groupIntoTurns(messages);
     expect(turns[0].llmCalls[0].model).toBe("claude-sonnet-4-5");
+  });
+
+  it.each([
+    ["captures top-level effort", { effort: "high" }, "high"],
+    ["leaves effort undefined when the transcript omits it", {}, undefined],
+  ] as const)("%s", (_, overrides, expected) => {
+    const messages: TranscriptMessage[] = [
+      makeUser("Hi"),
+      makeAssistant("msg_1", "Hello", overrides),
+    ];
+    expect(groupIntoTurns(messages)[0].llmCalls[0].effort).toBe(expected);
   });
 
   it("returns empty array for no messages", () => {

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -258,6 +258,7 @@ function mergeAssistantChunks(chunks: AssistantMessage[]): {
   content: ContentBlock[];
   model: string;
   usage: Usage;
+  effort?: string;
   startTime: string;
   endTime: string;
 } {
@@ -276,6 +277,7 @@ function mergeAssistantChunks(chunks: AssistantMessage[]): {
     content: merged,
     model: stripModelDateSuffix(first.message.model),
     usage: last.message.usage, // SSE usage is cumulative; last chunk has final totals.
+    effort: chunks.find((c) => c.effort)?.effort, // Only some chunks carry effort; take the first.
     startTime: first.timestamp,
     endTime: last.timestamp,
   };
@@ -393,6 +395,7 @@ export function groupIntoTurns(messages: TranscriptMessage[]): Turn[] {
         content: merged.content,
         model: merged.model,
         usage: merged.usage,
+        effort: merged.effort,
         startTime: merged.startTime,
         endTime: merged.endTime,
         toolCalls,

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface Usage {
   output_tokens: number;
   cache_read_input_tokens?: number;
   cache_creation_input_tokens?: number;
+  service_tier?: string | null;
 }
 
 /** A user message (human input) in the transcript. */
@@ -114,6 +115,7 @@ export interface AssistantMessage {
   };
   timestamp: string;
   promptId?: string;
+  effort?: string;
 }
 
 export type TranscriptMessage = UserMessage | ToolResultMessage | AssistantMessage;
@@ -143,6 +145,8 @@ export interface LLMCall {
   startTime: string;
   /** Timestamp of last chunk (end time). */
   endTime: string;
+  /** Reasoning effort the call ran at, when the transcript records one. */
+  effort?: string;
   /** Tool calls made in this response. */
   toolCalls: ToolCall[];
   /** True if this LLM call was synthesized (not from the transcript). */


### PR DESCRIPTION
What:

- Read `effort` and `service_tier` off the transcript and stamp them onto LLM runs in `ls_invocation_params` only when present. `effort` sits outside the nested `message` object so the parser wasn't picking it up
- Carry `effort` onto the synthetic final LLM call in `src/hooks/stop.ts`, which already inherits `model` the same way
- Fix a README line claiming `ls_invocation_params` holds "stop reason" (It doesn't)

Why:

- [LSDK-417](https://linear.app/langchain/issue/LSDK-417/claude-code-plugin-surface-effort-and-thinking-config-service-tier-in) Customer needs the effort a call actually ran at. The `CC_LANGSMITH_METADATA` workaround stamps one fixed value on every run so it goes stale mid-session or across subagents

## Test Plan

- [x] `pnpm test` (1667), `pnpm build`, `oxlint`, `oxfmt` pass; `bundle/` regenerates byte-identical
- [x] Same two-turn session on LangSmith dev, switching `--effort` between turns: [this branch](https://dev.smith.langchain.com/o/d6684905-655c-429b-bd14-ba302d94c03b/projects/p/db232598-39c5-4d31-a7a5-2b060ec9cb0e/t/4908386d-a372-40f3-9372-edebfe39c4e1) caught `low` then `high` with `service_tier`; [main](https://dev.smith.langchain.com/o/d6684905-655c-429b-bd14-ba302d94c03b/projects/p/db232598-39c5-4d31-a7a5-2b060ec9cb0e/t/412e9d09-d722-4978-aa30-0a47fbb609a2) showed only `model` on both
- [x] No unit test covers the `src/hooks/stop.ts` carry-over; a local bundle smoke does
